### PR TITLE
Correct macOS Arduino path in docs file

### DIFF
--- a/docs/iot-devkit.md
+++ b/docs/iot-devkit.md
@@ -35,7 +35,7 @@ Follow these steps to prepare the development environment for the IoT DevKit:
   * macOS
 
     ```JSON
-    "arduino.path": "/Application",
+    "arduino.path": "/Applications",
     "arduino.additionalUrls": "https://raw.githubusercontent.com/VSChina/azureiotdevkit_tools/master/package_azureboard_index.json"
     ```
 


### PR DESCRIPTION
The "/Application" is an incorrect path to Arduino IDE.