### PR TITLE
Correcting Mac Applications path

### DIFF
--- a/docs/iot-devkit/devkit-get-started.md
+++ b/docs/iot-devkit/devkit-get-started.md
@@ -90,7 +90,7 @@ Follow these steps to prepare the development environment for the IoT DevKit:
 	* macOS
 
 		```JSON
-		"arduino.path": "/Application",
+		"arduino.path": "/Applications",
 		"arduino.additionalUrls": "https://raw.githubusercontent.com/VSChina/azureiotdevkit_tools/master/package_azureboard_index.json"
 		```
 


### PR DESCRIPTION
The path to the MacOS Applications folder for the properties JSON file has been corrected to `Applications`