### PR TITLE
Remove the ModelDefinition from default DCM template.

### DIFF
--- a/resources/templates/devicemodel/sample.capabilitymodel.json
+++ b/resources/templates/devicemodel/sample.capabilitymodel.json
@@ -6,10 +6,6 @@
     {
       "schema": "urn:azureiot:DeviceManagement:DeviceInformation:1",
       "name": "deviceInfo"
-    },
-    {
-      "schema": "urn:azureiot:ModelDiscovery:ModelDefinition:1",
-      "name": "modelDefinition"
     }
   ],
   "@context": "http://azureiot.com/v1/contexts/IoTModel.json"


### PR DESCRIPTION
There is a issue on platform side, that sdk can't work properly with AICS if a defice has ModelDefinition interface.
