### PR TITLE
rename DPS terms in generated code for PnP

### DIFF
--- a/resources/templates/ansic_cmake_iotcsaskey/Readme.md
+++ b/resources/templates/ansic_cmake_iotcsaskey/Readme.md
@@ -29,14 +29,14 @@ For more details about setting up your development environment for compiling the
     * Open `main.c`. Specify paramaters requested by the commented **TODO's** for your configuration.
 
       ```c
-      // TODO: Specify DPS scope ID if you intend on using IoT Central.
-      static const char* dpsIdScope = "[DPS Id Scope]";
+      // TODO: Specify DPS ID scope if you intend on using DPS / IoT Central.
+      static const char *dpsIdScope = "[DPS ID Scope]";
 
-      // TODO: Specify symmetric keys if you intend on using IoT Central and symmetric key based auth.
-      static const char* sasKey = "[DPS symmetric key]";
+      // TODO: Specify symmetric keys if you intend on using DPS / IoT Central and symmetric key based auth.
+      static const char *sasKey = "[DPS symmetric key]";
 
-      // TODO: specify your device registration ID
-      static const char* registrationId = "[registration Id]";
+      // TODO: specify your device ID.
+      static const char *deviceId = "[device ID]";
       ```
 
 1. Open the `CMakeLists.txt` in the **azure-iot-sdk-c-pnp** folder. Include the **{PROJECT_NAME}** folder so that it will be built together with the Device SDK. Add the line below to the end of the file.
@@ -95,7 +95,7 @@ For more details about setting up your development environment for compiling the
       static const char *sasKey = "[DPS symmetric key]";
       
       // TODO: specify your device registration ID
-      static const char *registrationId = "[device registration Id]";
+      static const char *deviceId = "[device registration Id]";
       ```
 
 1. Open the `CMakeLists.txt` in the **azure-iot-sdk-c-pnp** folder. Include the **{PROJECT_NAME}** folder so that it will be built together with the Device SDK. Add the line below to the end of the file.

--- a/resources/templates/ansic_cmake_iotcsaskey/main.c
+++ b/resources/templates/ansic_cmake_iotcsaskey/main.c
@@ -34,14 +34,14 @@ const IOTHUB_SECURITY_TYPE secureDeviceTypeForIotHub = IOTHUB_SECURITY_TYPE_SYMM
 // The DPS global device endpoint
 static const char *globalDpsEndpoint = "global.azure-devices-provisioning.net";
 
-// TODO: Specify DPS scope ID if you intend on using DPS / IoT Central.
-static const char *dpsIdScope = "[DPS Id Scope]";
+// TODO: Specify DPS ID scope if you intend on using DPS / IoT Central.
+static const char *dpsIdScope = "[DPS ID Scope]";
 
 // TODO: Specify symmetric keys if you intend on using DPS / IoT Central and symmetric key based auth.
 static const char *sasKey = "[DPS symmetric key]";
 
-// TODO: specify your device registration ID
-static const char *registrationId = "[device registration Id]";
+// TODO: specify your device ID.
+static const char *deviceId = "[device ID]";
 
 // TODO: Fill in DIGITALTWIN_DEVICE_CAPABILITY_MODEL_INLINE_DATA if want to make deivce self-describing.
 #define DIGITALTWIN_DEVICE_CAPABILITY_MODEL_INLINE_DATA "{}"
@@ -112,7 +112,7 @@ static bool registerDevice(bool traceOn)
         return false;
     }
 
-    if (prov_dev_set_symmetric_key_info(registrationId, sasKey) != 0)
+    if (prov_dev_set_symmetric_key_info(deviceId, sasKey) != 0)
     {
         LogError("prov_dev_set_symmetric_key_info failed.");
     }

--- a/resources/templates/ansic_devkit_iotcsaskey/main.ino
+++ b/resources/templates/ansic_devkit_iotcsaskey/main.ino
@@ -42,8 +42,8 @@ static char *globalDpsEndpoint = NULL;
 static char *dpsIdScope = NULL;
 // The symmetric key, learn more from https://docs.microsoft.com/en-us/azure/iot-dps/concepts-symmetric-key-attestation.
 static char *sasKey = NULL;
-// The Registration ID, learn more from https://docs.microsoft.com/en-us/azure/iot-dps/use-hsm-with-sdk.
-static char *registrationId = NULL;
+// The device ID, learn more from https://docs.microsoft.com/en-us/azure/iot-dps/use-hsm-with-sdk.
+static char *deviceId = NULL;
 
 // TODO: Fill in DIGITALTWIN_DEVICE_CAPABILITY_MODEL_INLINE_DATA if want to make deivce self-describing.
 #define DIGITALTWIN_DEVICE_CAPABILITY_MODEL_INLINE_DATA "{}"
@@ -118,7 +118,7 @@ static bool parseDPSConnectionString(const char *connection_string)
     }
     if (_registrationId)
     {
-        mallocAndStrcpy_s(&registrationId, _registrationId);
+        mallocAndStrcpy_s(&deviceId, _registrationId);
     }
     else
     {
@@ -126,7 +126,7 @@ static bool parseDPSConnectionString(const char *connection_string)
     }  
     Map_Destroy(connection_string_values_map);
 
-    if (globalDpsEndpoint == NULL || dpsIdScope == NULL || sasKey == NULL || registrationId == NULL)
+    if (globalDpsEndpoint == NULL || dpsIdScope == NULL || sasKey == NULL || deviceId == NULL)
     {
         return false;
     }
@@ -178,7 +178,7 @@ static bool registerDevice(bool traceOn)
         return false;
     }
 
-    if (prov_dev_set_symmetric_key_info(registrationId, sasKey) != 0)
+    if (prov_dev_set_symmetric_key_info(deviceId, sasKey) != 0)
     {
         LogError("prov_dev_set_symmetric_key_info failed.");
     }

--- a/resources/templates/ansic_vs_iotcsaskey/Readme.md
+++ b/resources/templates/ansic_vs_iotcsaskey/Readme.md
@@ -29,14 +29,14 @@ For more details about setting up your development environment for compiling the
     * Open `main.c`. Specify paramaters requested by the commented **TODO's** for your configuration.
 
       ```c
-      // TODO: Specify DPS scope ID if you intend on using IoT Central.
+      // TODO: Specify DPS ID Scope if you intend on using DPS / IoT Central.
       static const char* dpsIdScope = "[DPS Id Scope]";
 
-      // TODO: Specify symmetric keys if you intend on using IoT Central and symmetric key based auth.
+      // TODO: Specify symmetric keys if you intend on using DPS / IoT Central with symmetric key based auth.
       static const char* sasKey = "[DPS symmetric key]";
 
-      // TODO: specify your device registration ID
-      static const char* registrationId = "[registration Id]";
+      // TODO: specify your device ID.
+      static const char* deviceId = "[device Id]";
       ```
 
 1. Open the `CMakeLists.txt` in the **azure-iot-sdk-c-pnp** folder. Include the **{PROJECT_NAME}** folder so that it will be built together with the Device SDK. Add the line below to the end of the file.

--- a/resources/templates/ansic_vs_iotcsaskey/main.c
+++ b/resources/templates/ansic_vs_iotcsaskey/main.c
@@ -34,14 +34,14 @@ const IOTHUB_SECURITY_TYPE secureDeviceTypeForIotHub = IOTHUB_SECURITY_TYPE_SYMM
 // The DPS global device endpoint
 static const char *globalDpsEndpoint = "global.azure-devices-provisioning.net";
 
-// TODO: Specify DPS scope ID if you intend on using DPS / IoT Central.
-static const char *dpsIdScope = "[DPS Id Scope]";
+// TODO: Specify DPS ID Scope if you intend on using DPS / IoT Central.
+static const char *dpsIdScope = "[DPS ID Scope]";
 
-// TODO: Specify symmetric keys if you intend on using DPS / IoT Central and symmetric key based auth.
+// TODO: Specify symmetric keys if you intend on using DPS / IoT Central with symmetric key based auth.
 static const char *sasKey = "[DPS symmetric key]";
 
-// TODO: specify your device registration ID
-static const char *registrationId = "[device registration Id]";
+// TODO: specify your device ID.
+static const char *deviceId = "[device ID]";
 
 // TODO: Fill in DIGITALTWIN_DEVICE_CAPABILITY_MODEL_INLINE_DATA if want to make deivce self-describing.
 #define DIGITALTWIN_DEVICE_CAPABILITY_MODEL_INLINE_DATA "{}"
@@ -112,7 +112,7 @@ static bool registerDevice(bool traceOn)
         return false;
     }
 
-    if (prov_dev_set_symmetric_key_info(registrationId, sasKey) != 0)
+    if (prov_dev_set_symmetric_key_info(deviceId, sasKey) != 0)
     {
         LogError("prov_dev_set_symmetric_key_info failed.");
     }


### PR DESCRIPTION
Align with PnP team, in all UIs and user visible surfaces, in order to keep the naming consistency, we are going to
- Change ‘Scope ID’ to ‘**ID Scope**’
- Change ‘registrationID’ to ‘**deviceID**’

@JerryYangKai once you've finished the rename items as follows, please let me know, I'll update the rest of documents/code snippet.
1. You need to update the [http server](https://github.com/microsoft/devkit-sdk/blob/master/AZ3166/src/cores/arduino/httpserver/app_httpd.cpp) to read DPS value from config portal and rename the DPS connection string format, and release a new package for AZ3166.

    - Current DPS connection string format: DPSEndpoint=[DPS global endpoint];ScopeId=[Scope ID];RegistrationId=[Registration ID];SymmetricKey=[symmetric key]
    - Expected format: DPSEndpoint=[DPS global endpoint];IdScope=[ID Scope];DeviceId=[Device ID];SymmetricKey=[symmetric key]

2. You need to refresh the DPS example.
