### PR TITLE
Bug fix: return directly when compile->configure as Embedded Linux pr…

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -519,7 +519,9 @@ export async function handleExternalProject(
 
     // If external project, construct as RaspberryPi Device based
     // container iot workbench project
-    await project.configExternalProjectToIotProject(scaffoldType);
+    if (!await project.configExternalProjectToIotProject(scaffoldType)) {
+      return;
+    }
 
     let res = await project.load(scaffoldType);
     if (!res) {


### PR DESCRIPTION
…oject finds not cmake project

Scenario:
1. Open an empty folder. Select "Compile device code" and choose to configured as Embedded Linux project.
2. Workbench finds no CMakeLists.txt. Should return directly with warning message.