### PR TITLE
Add workflow to mark and close stale issues

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -1,0 +1,21 @@
+name: Mark stale issues and close them
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: blackchoey/stale@releases/v1.2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue has been automatically marked as stale because it has no recent activities. It will be closed if no further activity occurs within 3 days. Thank you for your contributions.'
+        stale-issue-label: 'stale'
+        days-before-stale: 7
+        only-labels: 'need more info'
+        last-updated-user-type: 'collaborator'
+        days-before-close: 3

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -19,3 +19,4 @@ jobs:
         only-labels: 'need more info'
         last-updated-user-type: 'collaborator'
         days-before-close: 3
+        operations-per-run: 150


### PR DESCRIPTION
If an issue with label `need more info` has no activities in recent 7 days and it's last updated by collaborators, `stale` label will be added to the issue with comment.
If an issue is labeled `stale` and has no activities in next 3 days, the issue will be closed.