### PR TITLE
Add workflow to pickup issues that need attention

### DIFF
--- a/.github/workflows/need-attention-issues.yml
+++ b/.github/workflows/need-attention-issues.yml
@@ -1,0 +1,20 @@
+name: Pickup issues that needs attention
+
+on:
+  schedule:
+    - cron: "0 * * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: blackchoey/stale@releases/v1.2
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Collaborators, please take a look at this issue and provide updates for it.'
+        stale-issue-label: 'need attention'
+        days-before-stale: 3
+        last-updated-user-type: 'non-collaborator'
+        days-before-close: 999

--- a/.github/workflows/need-attention-issues.yml
+++ b/.github/workflows/need-attention-issues.yml
@@ -18,3 +18,4 @@ jobs:
         days-before-stale: 3
         last-updated-user-type: 'non-collaborator'
         days-before-close: 999
+        operations-per-run: 150


### PR DESCRIPTION
If an issue is last updated by users (non-collaborator) and has no activities in 3 days, `need attention` label will be added to attract attention. Further notification will be sent based on the label.