### PR TITLE
Fix auto popup landing page

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,10 +147,6 @@
           "IoTWorkbench.functionAppId": {
             "type": "string"
           },
-          "IoTWorkbench.disableAutoPopupLandingPage": {
-            "type": "boolean",
-            "default": false
-          },
           "IoTWorkbench.BoardId": {
             "type": "string"
           },

--- a/src/DigitalTwin/CodeGeneratorCore.ts
+++ b/src/DigitalTwin/CodeGeneratorCore.ts
@@ -11,7 +11,7 @@ import * as path from 'path';
 import request = require('request-promise');
 
 import * as utils from '../utils';
-import {FileNames, ConfigKey, ScaffoldType} from '../constants';
+import {FileNames, ConfigKey, ScaffoldType, OSPlatform} from '../constants';
 import {TelemetryContext} from '../telemetry';
 import {DigitalTwinConstants} from './DigitalTwinConstants';
 import {CodeGenProjectType, DeviceConnectionType, CodeGenLanguage, DeviceSdkReferenceType, CodeGenExecutionItem} from './DigitalTwinCodeGen/Interfaces/CodeGenerator';
@@ -555,7 +555,7 @@ export class CodeGeneratorCore {
         ConfigHandler.get<string>(ConfigKey.codeGeneratorVersion);
     let codeGenCliAppPath =
         path.join(localCodeGenCliPath(), DigitalTwinConstants.codeGenCliApp);
-    if (platform === 'win32') {
+    if (platform === OSPlatform.WIN32) {
       codeGenCliAppPath += '.exe';
     }
 
@@ -573,10 +573,10 @@ export class CodeGeneratorCore {
     let packageUri: string;
     let md5value: string;
     const platform = os.platform();
-    if (platform === 'win32') {
+    if (platform === OSPlatform.WIN32) {
       packageUri = targetConfigItem.codeGeneratorLocation.win32PackageUrl;
       md5value = targetConfigItem.codeGeneratorLocation.win32Md5;
-    } else if (platform === 'darwin') {
+    } else if (platform === OSPlatform.DARWIN) {
       packageUri = targetConfigItem.codeGeneratorLocation.macOSPackageUrl;
       md5value = targetConfigItem.codeGeneratorLocation.macOSMd5;
     } else {

--- a/src/DigitalTwin/DigitalTwinCodeGen/Interfaces/AnsiCCodeGenerator.ts
+++ b/src/DigitalTwin/DigitalTwinCodeGen/Interfaces/AnsiCCodeGenerator.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 
 import {VscodeCommands} from '../../../common/Commands';
-import {ScaffoldType} from '../../../constants';
+import {OSPlatform, ScaffoldType} from '../../../constants';
 import {OpenScenario} from '../../../Models/IoTWorkbenchProjectBase';
 import {IoTWorkspaceProject} from '../../../Models/IoTWorkspaceProject';
 import {TelemetryContext} from '../../../telemetry';
@@ -59,7 +59,7 @@ export class AnsiCCodeGenerator implements CodeGenerator {
     const homeDir = os.homedir();
     const cmdPath = path.join(homeDir, DigitalTwinConstants.codeGenCliFolder);
     let codeGenCommand = '';
-    if (platform === 'win32') {
+    if (platform === OSPlatform.WIN32) {
       codeGenCommand = `${DigitalTwinConstants.codeGenCliApp}.exe`;
     } else {
       codeGenCommand = `./${DigitalTwinConstants.codeGenCliApp}`;

--- a/src/IoTSettings.ts
+++ b/src/IoTSettings.ts
@@ -16,44 +16,63 @@ export class IoTWorkbenchSettings {
 
   private constructor() {}
 
-  static async getInstance() {
-    if (!this.instance) {
-      this.instance = new IoTWorkbenchSettings();
-      this.instance.workbenchPath =
+  static async getInstance(): Promise<IoTWorkbenchSettings> {
+    if (!IoTWorkbenchSettings.instance) {
+      IoTWorkbenchSettings.instance = new IoTWorkbenchSettings();
+      IoTWorkbenchSettings.instance.workbenchPath =
           ConfigHandler.get<string>(ConfigKey.workbench) ||
           (await this.getDefaultWorkbenchPath());
       await ConfigHandler.update(
-          ConfigKey.workbench, this.instance.workbenchPath,
+          ConfigKey.workbench, IoTWorkbenchSettings.instance.workbenchPath,
           vscode.ConfigurationTarget.Global);
     }
 
-    return this.instance;
+    return IoTWorkbenchSettings.instance;
   }
 
   static async getDefaultWorkbenchPath(): Promise<string> {
     const platform = await getPlatform();
     const homeDir = await getHomeDir();
 
-    let _workbenchPath = '';
+    let workbenchPath = '';
     if (platform === OSPlatform.WIN32) {
-      _workbenchPath = path.join(homeDir, 'Documents', 'IoTWorkbenchProjects');
+      workbenchPath = path.join(homeDir, 'Documents', 'IoTWorkbenchProjects');
     } else if (platform === OSPlatform.LINUX) {
-      _workbenchPath = path.join(homeDir, 'IoTWorkbenchProjects');
+      workbenchPath = path.join(homeDir, 'IoTWorkbenchProjects');
     } else if (platform === OSPlatform.DARWIN) {
-      _workbenchPath = path.join(homeDir, 'Documents', 'IoTWorkbenchProjects');
+      workbenchPath = path.join(homeDir, 'Documents', 'IoTWorkbenchProjects');
     } else {
-      _workbenchPath = '/IoTWorkbenchProjects';
+      workbenchPath = '/IoTWorkbenchProjects';
     }
 
-    return _workbenchPath;
+    return workbenchPath;
   }
 
   getWorkbenchPath(): string {
     return ConfigHandler.get<string>(ConfigKey.workbench) || this.workbenchPath;
   }
 
-  async setWorkbenchPath(showMessage = true): Promise<void> {
-    let userWorkbenchPath = this.getWorkbenchPath();
+  async setWorkbenchPath(): Promise<void> {
+    const selection = await this.selectWorkbenchPath();
+
+    let userWorkbenchPath;
+    if (selection.data === '$') {
+      userWorkbenchPath = await this.selectFolder();
+    } else {
+      userWorkbenchPath = selection.data;
+    }
+
+    if (userWorkbenchPath) {
+      await ConfigHandler.update(
+          ConfigKey.workbench, userWorkbenchPath,
+          vscode.ConfigurationTarget.Global);
+      await vscode.window.showInformationMessage(
+          'Change workbench successfully.');
+    }
+  }
+
+  private async selectWorkbenchPath(): Promise<PickWithData<string>> {
+    const userWorkbenchPath = this.getWorkbenchPath();
     const workbenchPicks: Array<PickWithData<string>> = [
       {label: userWorkbenchPath, description: '', data: userWorkbenchPath},
       {label: '$(file-directory) Browse...', description: '', data: '$'}
@@ -66,37 +85,25 @@ export class IoTWorkbenchSettings {
       placeHolder: 'Select workbench folder'
     });
 
-    if (selection && selection.data === '$') {
-      const options: vscode.OpenDialogOptions = {
-        canSelectMany: false,
-        openLabel: 'Select',
-        canSelectFolders: true,
-        canSelectFiles: false
-      };
+    if (!selection) {
+      throw new CancelOperationError('Workbench path selection cancelled.');
+    }
+    return selection;
+  }
 
-      const folderUri = await vscode.window.showOpenDialog(options);
-      if (folderUri && folderUri[0]) {
-        userWorkbenchPath = folderUri[0].fsPath;
-      } else {
-        if (showMessage) {
-          throw new CancelOperationError('Change workbench cancelled.');
-        }
-        return;
-      }
-    } else if (selection !== undefined) {
-      userWorkbenchPath = selection.data;
-    } else {
-      userWorkbenchPath = '';
+  private async selectFolder(): Promise<string> {
+    const options: vscode.OpenDialogOptions = {
+      canSelectMany: false,
+      openLabel: 'Select',
+      canSelectFolders: true,
+      canSelectFiles: false
+    };
+
+    const folderUri = await vscode.window.showOpenDialog(options);
+    if (!(folderUri && folderUri.length > 0)) {
+      throw new CancelOperationError('Folder selection cancelled.');
     }
 
-    if (userWorkbenchPath) {
-      await ConfigHandler.update(
-          ConfigKey.workbench, userWorkbenchPath,
-          vscode.ConfigurationTarget.Global);
-      if (showMessage) {
-        await vscode.window.showInformationMessage(
-            'Change workbench successfully.');
-      }
-    }
+    return folderUri[0].fsPath;
   }
 }

--- a/src/IoTSettings.ts
+++ b/src/IoTSettings.ts
@@ -100,7 +100,7 @@ export class IoTWorkbenchSettings {
     };
 
     const folderUri = await vscode.window.showOpenDialog(options);
-    if (!(folderUri && folderUri.length > 0)) {
+    if (!folderUri || folderUri.length === 0) {
       throw new CancelOperationError('Folder selection cancelled.');
     }
 

--- a/src/Models/AZ3166Device.ts
+++ b/src/Models/AZ3166Device.ts
@@ -395,8 +395,8 @@ export class AZ3166Device extends ArduinoDeviceBase {
     }
 
     // Set selected connection string to device
-    const plat = os.platform();
-    if (plat === OSPlatform.WIN32) {
+    const platform = os.platform();
+    if (platform === OSPlatform.WIN32) {
       return await this.flushDeviceConfig(configValue, option);
     } else {
       return await this.flushDeviceConfigUnixAndMac(configValue, option);
@@ -731,8 +731,8 @@ export class AZ3166Device extends ArduinoDeviceBase {
   }
 
   private async stlinkDriverInstalled() {
-    const plat = os.platform();
-    if (plat === OSPlatform.WIN32) {
+    const platform = os.platform();
+    if (platform === OSPlatform.WIN32) {
       try {
         // The STlink driver would write to the following registry.
         const pathString = await getRegistryValues(
@@ -815,19 +815,19 @@ export class AZ3166Device extends ArduinoDeviceBase {
   }
 
   private getArduinoPackagePath() {
-    const plat = os.platform();
+    const platform = os.platform();
 
     // TODO: Currently, we do not support portable Arduino installation.
     let arduinoPackagePath = '';
     const homeDir = os.homedir();
 
-    if (plat === OSPlatform.WIN32) {
+    if (platform === OSPlatform.WIN32) {
       arduinoPackagePath =
           path.join(homeDir, 'AppData', 'Local', 'Arduino15', 'packages');
-    } else if (plat === OSPlatform.DARWIN) {
+    } else if (platform === OSPlatform.DARWIN) {
       arduinoPackagePath =
           path.join(homeDir, 'Library', 'Arduino15', 'packages');
-    } else if (plat === OSPlatform.LINUX) {
+    } else if (platform === OSPlatform.LINUX) {
       arduinoPackagePath = path.join(homeDir, '.arduino15', 'packages');
     }
 

--- a/src/Models/AZ3166Device.ts
+++ b/src/Models/AZ3166Device.ts
@@ -732,7 +732,7 @@ export class AZ3166Device extends ArduinoDeviceBase {
 
   private async stlinkDriverInstalled() {
     const plat = os.platform();
-    if (plat === 'win32') {
+    if (plat === OSPlatform.WIN32) {
       try {
         // The STlink driver would write to the following registry.
         const pathString = await getRegistryValues(
@@ -821,13 +821,13 @@ export class AZ3166Device extends ArduinoDeviceBase {
     let arduinoPackagePath = '';
     const homeDir = os.homedir();
 
-    if (plat === 'win32') {
+    if (plat === OSPlatform.WIN32) {
       arduinoPackagePath =
           path.join(homeDir, 'AppData', 'Local', 'Arduino15', 'packages');
-    } else if (plat === 'darwin') {
+    } else if (plat === OSPlatform.DARWIN) {
       arduinoPackagePath =
           path.join(homeDir, 'Library', 'Arduino15', 'packages');
-    } else if (plat === 'linux') {
+    } else if (plat === OSPlatform.LINUX) {
       arduinoPackagePath = path.join(homeDir, '.arduino15', 'packages');
     }
 

--- a/src/Models/ArduinoDeviceBase.ts
+++ b/src/Models/ArduinoDeviceBase.ts
@@ -9,7 +9,6 @@ import {VscodeCommands} from '../common/Commands';
 import {ConfigHandler} from '../configHandler';
 import {ConfigKey, DependentExtensions, FileNames, OperationType, OSPlatform, ScaffoldType} from '../constants';
 import {FileUtility} from '../FileUtility';
-import {IoTWorkbenchSettings} from '../IoTSettings';
 import {TelemetryContext} from '../telemetry';
 import * as utils from '../utils';
 
@@ -183,7 +182,7 @@ export abstract class ArduinoDeviceBase implements Device {
 
     let cppPropertiesTemplateFileName: string;
     let changeRootPath = false;
-    let rootPath: string = await IoTWorkbenchSettings.getOs();
+    let rootPath: string = await utils.getHomeDir();
     if (platform === OSPlatform.WIN32) {
       rootPath = path.join(rootPath, 'AppData', 'Local').replace(/\\/g, '\\\\');
       cppPropertiesTemplateFileName = constants.cppPropertiesFileNameWin;
@@ -224,7 +223,7 @@ export abstract class ArduinoDeviceBase implements Device {
 
     // Create c_cpp_properties.json file
     try {
-      const platform = await IoTWorkbenchSettings.getPlatform();
+      const platform = await utils.getPlatform();
       await this.writeCppPropertiesFile(board.id, type, platform);
     } catch (error) {
       throw new Error(`Create cpp properties file failed: ${error.message}`);

--- a/src/Models/Esp32Device.ts
+++ b/src/Models/Esp32Device.ts
@@ -10,8 +10,7 @@ import * as vscode from 'vscode';
 
 import {BoardProvider} from '../boardProvider';
 import {ConfigHandler} from '../configHandler';
-import {ConfigKey, ScaffoldType} from '../constants';
-import {FileUtility} from '../FileUtility';
+import {ConfigKey} from '../constants';
 import {TelemetryContext} from '../telemetry';
 
 import {ArduinoDeviceBase} from './ArduinoDeviceBase';

--- a/src/Models/Esp32Device.ts
+++ b/src/Models/Esp32Device.ts
@@ -10,7 +10,7 @@ import * as vscode from 'vscode';
 
 import {BoardProvider} from '../boardProvider';
 import {ConfigHandler} from '../configHandler';
-import {ConfigKey} from '../constants';
+import {ConfigKey, OSPlatform} from '../constants';
 import {TelemetryContext} from '../telemetry';
 
 import {ArduinoDeviceBase} from './ArduinoDeviceBase';
@@ -41,7 +41,7 @@ export class Esp32Device extends ArduinoDeviceBase {
     let packageRootPath = '';
     let version = '0.0.1';
 
-    if (plat === 'win32') {
+    if (plat === OSPlatform.WIN32) {
       const homeDir = os.homedir();
       const localAppData: string = path.join(homeDir, 'AppData', 'Local');
       packageRootPath = path.join(

--- a/src/Models/Esp32Device.ts
+++ b/src/Models/Esp32Device.ts
@@ -37,11 +37,11 @@ export class Esp32Device extends ArduinoDeviceBase {
   }
 
   get version() {
-    const plat = os.platform();
+    const platform = os.platform();
     let packageRootPath = '';
     let version = '0.0.1';
 
-    if (plat === OSPlatform.WIN32) {
+    if (platform === OSPlatform.WIN32) {
       const homeDir = os.homedir();
       const localAppData: string = path.join(homeDir, 'AppData', 'Local');
       packageRootPath = path.join(

--- a/src/common/Commands.ts
+++ b/src/common/Commands.ts
@@ -16,10 +16,7 @@ export enum WorkbenchCommands {
   ExampleInitialize = 'iotworkbench.exampleInitialize',
   SendTelemetry = 'iotworkbench.sendTelemetry',
   OpenUri = 'iotworkbench.openUri',
-  HttpRequest = 'iotworkbench.httpRequest',
-  GetDisableAutoPopupLandingPage =
-      'iotworkbench.getDisableAutoPopupLandingPage',
-  SetDisableAutoPopupLandingPage = 'iotworkbench.setDisableAutoPopupLandingPage'
+  HttpRequest = 'iotworkbench.httpRequest'
 }
 
 export enum VscodeCommands {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 export class ConfigKey {
+  // Keys for condifurations in User / Workspace settings
   static readonly workbench = 'workbench';
   static readonly devicePath = 'DevicePath';
   static readonly functionPath = 'FunctionPath';
@@ -12,12 +13,14 @@ export class ConfigKey {
   static readonly functionAppId = 'functionAppId';
   static readonly boardId = 'BoardId';
   static readonly codeGeneratorVersion = 'IoTPnPCodeGenVersion';
-  static readonly disableAutoPopupLandingPage = 'disableAutoPopupLandingPage';
+  static readonly asaPath = 'StreamAnalyticsPath';
 
-  static readonly projectType = 'ProjectType';
+  // Keys for configurations in iot workbench project config file
   static readonly projectHostType = 'ProjectHostType';
   static readonly workbenchVersion = 'version';
-  static readonly asaPath = 'StreamAnalyticsPath';
+
+  // Keys for configurations in global state
+  static readonly hasPopUp = 'hasPopUp';
 }
 
 export class EventNames {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,21 +2,22 @@
 // Licensed under the MIT License.
 
 export class ConfigKey {
+  static readonly workbench = 'workbench';
   static readonly devicePath = 'DevicePath';
+  static readonly functionPath = 'FunctionPath';
   static readonly iotHubConnectionString = 'iothubConnectionString';
   static readonly iotHubDeviceConnectionString = 'iothubDeviceConnectionString';
   static readonly eventHubConnectionString = 'eventHubConnectionString';
   static readonly eventHubConnectionPath = 'eventHubConnectionPath';
   static readonly functionAppId = 'functionAppId';
-  static readonly functionPath = 'FunctionPath';
   static readonly boardId = 'BoardId';
-  static readonly asaPath = 'StreamAnalyticsPath';
   static readonly codeGeneratorVersion = 'IoTPnPCodeGenVersion';
+  static readonly disableAutoPopupLandingPage = 'disableAutoPopupLandingPage';
+
   static readonly projectType = 'ProjectType';
   static readonly projectHostType = 'ProjectHostType';
   static readonly workbenchVersion = 'version';
-
-  static readonly disableAutoPopupLandingPage = 'disableAutoPopupLandingPage';
+  static readonly asaPath = 'StreamAnalyticsPath';
 }
 
 export class EventNames {

--- a/src/exampleExplorer.ts
+++ b/src/exampleExplorer.ts
@@ -90,9 +90,8 @@ export class ExampleExplorer {
   }
 
   private async generateExampleFolder(exampleName: string) {
-    const settings: IoTWorkbenchSettings =
-        await IoTWorkbenchSettings.createAsync();
-    const workbench = await settings.workbenchPath();
+    const settings = await IoTWorkbenchSettings.getInstance();
+    const workbench = settings.getWorkbenchPath();
 
     if (!utils.directoryExistsSync(workbench)) {
       utils.mkdirRecursivelySync(workbench);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -183,21 +183,6 @@ export async function activate(context: vscode.ExtensionContext) {
     return res;
   });
 
-
-  initCommand(
-      context, WorkbenchCommands.GetDisableAutoPopupLandingPage, async () => {
-        return ConfigHandler.get<boolean>(
-            ConfigKey.disableAutoPopupLandingPage);
-      });
-
-  initCommand(
-      context, WorkbenchCommands.SetDisableAutoPopupLandingPage,
-      async (disableAutoPopupLandingPage: boolean) => {
-        return ConfigHandler.update(
-            ConfigKey.disableAutoPopupLandingPage, disableAutoPopupLandingPage,
-            vscode.ConfigurationTarget.Global);
-      });
-
   // delay to detect usb
   setTimeout(() => {
     enableUsbDetector(context, outputChannel);
@@ -218,7 +203,7 @@ function enableUsbDetector(
       impor('./usbDetector') as typeof import('./usbDetector');
 
   const usbDetector = new usbDetectorModule.UsbDetector(context, outputChannel);
-  usbDetector.startListening();
+  usbDetector.startListening(context);
 }
 
 function printHello(context: vscode.ExtensionContext) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -168,8 +168,7 @@ export async function activate(context: vscode.ExtensionContext) {
         if (!isLocal) {
           return;
         }
-        const settings: IoTWorkbenchSettings =
-            await IoTWorkbenchSettings.createAsync();
+        const settings = await IoTWorkbenchSettings.getInstance();
         await settings.setWorkbenchPath();
         return;
       });

--- a/src/projectInitializer.ts
+++ b/src/projectInitializer.ts
@@ -183,9 +183,8 @@ export class ProjectInitializer {
   private async generateProjectFolder(scaffoldType: ScaffoldType):
       Promise<string|undefined> {
     // Get default workbench path.
-    const settings: IoTWorkbenchSettings =
-        await IoTWorkbenchSettings.createAsync();
-    const workbench = await settings.workbenchPath();
+    const settings = await IoTWorkbenchSettings.getInstance();
+    const workbench = settings.getWorkbenchPath();
 
     const projectRootPath = path.join(workbench, 'projects');
     if (!await FileUtility.directoryExists(scaffoldType, projectRootPath)) {

--- a/src/usbDetector.ts
+++ b/src/usbDetector.ts
@@ -8,9 +8,9 @@ import {VSCExpress} from 'vscode-express';
 
 import {ArduinoPackageManager} from './ArduinoPackageManager';
 import {BoardProvider} from './boardProvider';
-import {ConfigHandler} from './configHandler';
-import {EventNames, FileNames, OSPlatform} from './constants';
+import {ConfigKey, EventNames, FileNames, OSPlatform} from './constants';
 import {TelemetryWorker} from './telemetry';
+import {shouldShowLandingPage} from './utils';
 
 export interface DeviceInfo {
   vendorId: number;
@@ -25,9 +25,8 @@ export class UsbDetector {
   constructor(
       private context: vscode.ExtensionContext,
       private channel: vscode.OutputChannel) {
-    const disableUSBDetection =
-        ConfigHandler.get<boolean>('disableAutoPopupLandingPage');
-    if (os.platform() === OSPlatform.LINUX || disableUSBDetection) {
+    const enableUSBDetection = shouldShowLandingPage(context);
+    if (os.platform() === OSPlatform.LINUX || !enableUSBDetection) {
       return;
     } else {
       // Only load detector module when not in remote
@@ -77,12 +76,14 @@ export class UsbDetector {
             }
           }, {}, {board: board.name});
     }
+
+    // Will not auto pop up landing page next time.
+    this.context.globalState.update(ConfigKey.hasPopUp, true);
   }
 
-  async startListening() {
-    const disableUSBDetection =
-        ConfigHandler.get<boolean>('disableAutoPopupLandingPage');
-    if (os.platform() === OSPlatform.LINUX || disableUSBDetection) {
+  async startListening(context: vscode.ExtensionContext) {
+    const enableUSBDetection = shouldShowLandingPage(context);
+    if (os.platform() === OSPlatform.LINUX || !enableUSBDetection) {
       return;
     }
 

--- a/src/usbDetector.ts
+++ b/src/usbDetector.ts
@@ -9,7 +9,7 @@ import {VSCExpress} from 'vscode-express';
 import {ArduinoPackageManager} from './ArduinoPackageManager';
 import {BoardProvider} from './boardProvider';
 import {ConfigHandler} from './configHandler';
-import {EventNames, FileNames} from './constants';
+import {EventNames, FileNames, OSPlatform} from './constants';
 import {TelemetryWorker} from './telemetry';
 
 export interface DeviceInfo {
@@ -27,7 +27,7 @@ export class UsbDetector {
       private channel: vscode.OutputChannel) {
     const disableUSBDetection =
         ConfigHandler.get<boolean>('disableAutoPopupLandingPage');
-    if (os.platform() === 'linux' || disableUSBDetection) {
+    if (os.platform() === OSPlatform.LINUX || disableUSBDetection) {
       return;
     } else {
       // Only load detector module when not in remote
@@ -82,7 +82,7 @@ export class UsbDetector {
   async startListening() {
     const disableUSBDetection =
         ConfigHandler.get<boolean>('disableAutoPopupLandingPage');
-    if (os.platform() === 'linux' || disableUSBDetection) {
+    if (os.platform() === OSPlatform.LINUX || disableUSBDetection) {
       return;
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -6,6 +6,7 @@ import * as fs from 'fs-plus';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import {MessageItem} from 'vscode';
+import * as sdk from 'vscode-iot-device-cube-sdk';
 import * as WinReg from 'winreg';
 
 import {CancelOperationError} from './CancelOperationError';
@@ -860,4 +861,18 @@ export async function getEnvTemplateFilesAndAskOverwrite(
   }
 
   return templateFilesInfo;
+}
+
+export async function getPlatform(): Promise<string> {
+  const localOs = sdk.Utility.require('os') as typeof import('os');
+  const getPlatform = await localOs.platform;
+  const platform = await getPlatform();
+  return platform;
+}
+
+export async function getHomeDir(): Promise<string> {
+  const localOs = sdk.Utility.require('os') as typeof import('os');
+  const getHomeDir = await localOs.homedir;
+  const homeDir = await getHomeDir();
+  return homeDir;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -876,3 +876,14 @@ export async function getHomeDir(): Promise<string> {
   const homeDir = await getHomeDir();
   return homeDir;
 }
+
+/**
+ * Whether to pop up landing page or not.
+ * If this is the first time user use workbench, then pop up landing page.
+ * If this is not the first time, don't pop up.
+ */
+export function shouldShowLandingPage(context: vscode.ExtensionContext):
+    boolean {
+  const hasPopUp = context.globalState.get<boolean>(ConfigKey.hasPopUp, false);
+  return !hasPopUp;
+}

--- a/views/example.html
+++ b/views/example.html
@@ -540,6 +540,8 @@ body.vscode-dark .tutorial {
 <body>
 <div id="example">
 <div id="main" v-cloak>
+  <h3>To open this page, you can open command pallete and select "<b>IoT Device Workbench: open Example...</b>"</h2>
+
   <div id="featured" v-if="featuredExample">
     <span v-if="featuredExample.difficulty" v-bind:class="'difficulty ' + featuredExample.difficulty"></span>
     <img v-bind:src="featuredExample.image || '/images/no-image.jpg'">
@@ -592,11 +594,6 @@ body.vscode-dark .tutorial {
       </div>
     </li>
   </ul>
-  
-  <div class="disable-auto-popup-landing-page">
-    <input id="disableAutoPopup" type="checkbox" v-model="disableAutoPopupLandingPage.value" v-on:change="updateDisableAutoPopupLandingPage">
-    <label for="disableAutoPopup">Disable auto popup landing page</label>
-  </div>
 </div>
 <aside id="aside"></aside>
 </div>

--- a/views/example.js
+++ b/views/example.js
@@ -10,15 +10,9 @@ var example = new Vue({
     officialExamples: [],
     communityExamples: [],
     blogs: [],
-    boardId: '',
-    disableAutoPopupLandingPage: {
-      value: false
-    }
+    boardId: ''
   },
   created: function() {
-    command('iotworkbench.getDisableAutoPopupLandingPage', function(disableAutoPopupLandingPage) {
-      Vue.set(example.disableAutoPopupLandingPage, 'value', disableAutoPopupLandingPage.result);
-    });
     const query = parseQuery(_location ? _location.href : location.href);
     const url = query.url ||
         'https://raw.githubusercontent.com/VSChina/azureiotdevkit_tools/gallery/workbench-example-devkit-v2.json';
@@ -75,10 +69,7 @@ var example = new Vue({
       }
       command('iotworkbench.exampleInitialize', name, url, boardId);
     },
-    openLink: openLink,
-    updateDisableAutoPopupLandingPage: function() {
-      command('iotworkbench.setDisableAutoPopupLandingPage', this.disableAutoPopupLandingPage.value);
-    }
+    openLink: openLink
   }
 });
 


### PR DESCRIPTION
1. Refactor IoTWorkbenchSettings to be singleton.
2. Replace os string 'win32'/'linux'/'darwin' with constants.
3. Fix auto pop up landing page: Only pop up when user first install iot workbench extension.