### PR TITLE
Fix telemetry context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2485,12 +2485,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2505,17 +2507,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2632,7 +2637,8 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2644,6 +2650,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2658,6 +2665,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2665,12 +2673,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2689,6 +2699,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2778,7 +2789,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2790,6 +2802,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2911,6 +2924,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -36,11 +36,11 @@ export async function activate(context: vscode.ExtensionContext) {
   const outputChannel: vscode.OutputChannel =
       vscode.window.createOutputChannel(channelName);
   telemetryWorker = TelemetryWorker.getInstance(context);
-  const telemetryContext = telemetryWorker.createContext();
   context.subscriptions.push(telemetryWorker);
 
   // Load iot Project here and do not ask to new an iot project when no iot
   // project open since no command has been triggered yet.
+  const telemetryContext = telemetryWorker.createContext();
   await constructAndLoadIoTProject(
       context, outputChannel, telemetryContext, true);
 
@@ -49,96 +49,117 @@ export async function activate(context: vscode.ExtensionContext) {
   const exampleExplorer = new exampleExplorerModule.ExampleExplorer();
 
   initCommandWithTelemetry(
-      context, telemetryWorker, telemetryContext, outputChannel,
+      context, telemetryWorker, outputChannel,
       WorkbenchCommands.InitializeProject, EventNames.createNewProjectEvent,
-      true, async(): Promise<void> => {
+      true,
+      async(
+          context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel,
+          telemetryContext: TelemetryContext): Promise<void> => {
         const projectInitializer = new ProjectInitializer();
         return projectInitializer.InitializeProject(
             context, outputChannel, telemetryContext);
       });
 
   initCommandWithTelemetry(
-      context, telemetryWorker, telemetryContext, outputChannel,
+      context, telemetryWorker, outputChannel,
       WorkbenchCommands.ConfigureProjectEnvironment,
       EventNames.configProjectEnvironmentEvent, true,
-      async(): Promise<void> => {
+      async(
+          context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel,
+          telemetryContext: TelemetryContext): Promise<void> => {
         const projectEnvConfiger = new ProjectEnvironmentConfiger();
         return projectEnvConfiger.configureCmakeProjectEnvironment(
             context, outputChannel, telemetryContext);
       });
 
   initCommandWithTelemetry(
-      context, telemetryWorker, telemetryContext, outputChannel,
-      WorkbenchCommands.AzureProvision, EventNames.azureProvisionEvent, true,
-      async(): Promise<void> => {
+      context, telemetryWorker, outputChannel, WorkbenchCommands.AzureProvision,
+      EventNames.azureProvisionEvent, true,
+      async(
+          context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel,
+          telemetryContext: TelemetryContext): Promise<void> => {
         return azureOperator.provision(
             context, outputChannel, telemetryContext);
       });
 
   initCommandWithTelemetry(
-      context, telemetryWorker, telemetryContext, outputChannel,
-      WorkbenchCommands.AzureDeploy, EventNames.azureDeployEvent, true,
-      async(): Promise<void> => {
+      context, telemetryWorker, outputChannel, WorkbenchCommands.AzureDeploy,
+      EventNames.azureDeployEvent, true,
+      async(
+          context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel,
+          telemetryContext: TelemetryContext): Promise<void> => {
         return azureOperator.deploy(context, outputChannel, telemetryContext);
       });
 
   initCommandWithTelemetry(
-      context, telemetryWorker, telemetryContext, outputChannel,
-      WorkbenchCommands.DeviceCompile, EventNames.deviceCompileEvent, true,
-      async(): Promise<void> => {
+      context, telemetryWorker, outputChannel, WorkbenchCommands.DeviceCompile,
+      EventNames.deviceCompileEvent, true,
+      async(
+          context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel,
+          telemetryContext: TelemetryContext): Promise<void> => {
         return deviceOperator.compile(context, outputChannel, telemetryContext);
       });
 
   initCommandWithTelemetry(
-      context, telemetryWorker, telemetryContext, outputChannel,
-      WorkbenchCommands.DeviceUpload, EventNames.deviceUploadEvent, true,
-      async(): Promise<void> => {
+      context, telemetryWorker, outputChannel, WorkbenchCommands.DeviceUpload,
+      EventNames.deviceUploadEvent, true,
+      async(
+          context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel,
+          telemetryContext: TelemetryContext): Promise<void> => {
         return deviceOperator.upload(context, outputChannel, telemetryContext);
       });
 
   initCommandWithTelemetry(
-      context, telemetryWorker, telemetryContext, outputChannel,
+      context, telemetryWorker, outputChannel,
       WorkbenchCommands.ConfigureDevice, EventNames.configDeviceSettingsEvent,
-      true, async(): Promise<void> => {
+      true,
+      async(
+          context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel,
+          telemetryContext: TelemetryContext): Promise<void> => {
         return deviceOperator.configDeviceSettings(
             context, outputChannel, telemetryContext);
       });
 
   initCommandWithTelemetry(
-      context, telemetryWorker, telemetryContext, outputChannel,
-      WorkbenchCommands.Examples, EventNames.openExamplePageEvent, true,
-      async(): Promise<void> => {
+      context, telemetryWorker, outputChannel, WorkbenchCommands.Examples,
+      EventNames.openExamplePageEvent, true,
+      async(
+          context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel,
+          telemetryContext: TelemetryContext): Promise<void> => {
         return exampleExplorer.selectBoard(
             context, outputChannel, telemetryContext);
       });
 
   initCommandWithTelemetry(
-      context, telemetryWorker, telemetryContext, outputChannel,
+      context, telemetryWorker, outputChannel,
       WorkbenchCommands.ExampleInitialize, EventNames.loadExampleEvent, true,
       async(
-          context, outputChannel, telemetryContext, name?: string, url?: string,
+          context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel,
+          telemetryContext: TelemetryContext, name?: string, url?: string,
           boardId?: string): Promise<void> => {
         return exampleExplorer.initializeExample(
             context, outputChannel, telemetryContext, name, url, boardId);
       });
 
   initCommandWithTelemetry(
-      context, telemetryWorker, telemetryContext, outputChannel,
-      WorkbenchCommands.SendTelemetry, EventNames.openTutorial, true,
-      async () => {});
+      context, telemetryWorker, outputChannel, WorkbenchCommands.SendTelemetry,
+      EventNames.openTutorial, true, async () => {});
 
   initCommandWithTelemetry(
-      context, telemetryWorker, telemetryContext, outputChannel,
+      context, telemetryWorker, outputChannel,
       WorkbenchCommands.IotPnPGenerateCode, EventNames.scaffoldDeviceStubEvent,
-      true, async(): Promise<void> => {
+      true,
+      async(
+          context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel,
+          telemetryContext: TelemetryContext): Promise<void> => {
         const codeGenerator = new CodeGeneratorCore();
         return codeGenerator.generateDeviceCodeStub(
             context, outputChannel, telemetryContext);
       });
 
   initCommandWithTelemetry(
-      context, telemetryWorker, telemetryContext, outputChannel,
-      WorkbenchCommands.Help, EventNames.help, true, async () => {
+      context, telemetryWorker, outputChannel, WorkbenchCommands.Help,
+      EventNames.help, true, async () => {
         const boardId = ConfigHandler.get<string>(ConfigKey.boardId);
 
         if (boardId) {
@@ -161,9 +182,8 @@ export async function activate(context: vscode.ExtensionContext) {
       });
 
   initCommandWithTelemetry(
-      context, telemetryWorker, telemetryContext, outputChannel,
-      WorkbenchCommands.Workbench, EventNames.setProjectDefaultPath, true,
-      async () => {
+      context, telemetryWorker, outputChannel, WorkbenchCommands.Workbench,
+      EventNames.setProjectDefaultPath, true, async () => {
         const isLocal = RemoteExtension.checkLocalBeforeRunCommand(context);
         if (!isLocal) {
           return;
@@ -219,8 +239,8 @@ function printHello(context: vscode.ExtensionContext) {
 
 function initCommandWithTelemetry(
     context: vscode.ExtensionContext, telemetryWorker: TelemetryWorker,
-    telemetryContext: TelemetryContext, outputChannel: vscode.OutputChannel,
-    command: WorkbenchCommands, eventName: string, enableSurvey: boolean,
+    outputChannel: vscode.OutputChannel, command: WorkbenchCommands,
+    eventName: string, enableSurvey: boolean,
     // tslint:disable-next-line:no-any
     callback: (
         context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel,
@@ -231,8 +251,8 @@ function initCommandWithTelemetry(
   context.subscriptions.push(vscode.commands.registerCommand(
       command,
       async (...commandArgs) => telemetryWorker.callCommandWithTelemetry(
-          context, telemetryContext, outputChannel, eventName, enableSurvey,
-          callback, additionalProperties, ...commandArgs)));
+          context, outputChannel, eventName, enableSurvey, callback,
+          additionalProperties, ...commandArgs)));
 }
 
 function initCommand(

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -118,9 +118,8 @@ export class TelemetryWorker {
    * @param additionalProperties
    */
   async callCommandWithTelemetry(
-      context: vscode.ExtensionContext, telemetryContext: TelemetryContext,
-      outputChannel: vscode.OutputChannel, eventName: string,
-      enableSurvey: boolean,
+      context: vscode.ExtensionContext, outputChannel: vscode.OutputChannel,
+      eventName: string, enableSurvey: boolean,
       // tslint:disable-next-line:no-any
       callback:
           (context: vscode.ExtensionContext,
@@ -131,6 +130,9 @@ export class TelemetryWorker {
       additionalProperties?: {[key: string]: string},
       // tslint:disable-next-line:no-any
       ...commandArgs: any[]): Promise<any> {
+    const telemetryWorker = TelemetryWorker.getInstance(context);
+    const telemetryContext = telemetryWorker.createContext();
+
     const start: number = Date.now();
     if (additionalProperties) {
       for (const key of Object.keys(additionalProperties)) {

--- a/src/usbDetector.ts
+++ b/src/usbDetector.ts
@@ -52,10 +52,9 @@ export class UsbDetector {
 
     if (board) {
       const telemetryWorker = TelemetryWorker.getInstance(this.context);
-      const telemetryContext = telemetryWorker.createContext();
 
       telemetryWorker.callCommandWithTelemetry(
-          this.context, telemetryContext, this.channel, EventNames.detectBoard,
+          this.context, this.channel, EventNames.detectBoard,
           false, async () => {
             if (board.exampleUrl) {
               ArduinoPackageManager.installBoard(board);


### PR DESCRIPTION
Create telemetry context inside function `callCommandWithTelemetry()` so that each command's telemetryContext can be distinct.