### PR TITLE
Bugs fix: auto configure; worspace config file name

### DIFF
--- a/src/CancelOperationError.ts
+++ b/src/CancelOperationError.ts
@@ -1,6 +1,6 @@
 export class CancelOperationError extends Error {
   constructor(message: string) {
-    super(`Openration cancelled: ${message}`);
+    super(`Operation cancelled: ${message}`);
     this.name = 'CancelOperationError';
   }
 }

--- a/src/Models/ArduinoDeviceBase.ts
+++ b/src/Models/ArduinoDeviceBase.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 
 import {VscodeCommands} from '../common/Commands';
 import {ConfigHandler} from '../configHandler';
-import {ConfigKey, DependentExtensions, FileNames, OperationType, OSPlatform, ScaffoldType} from '../constants';
+import {ConfigKey, DependentExtensions, FileNames, OperationType, OSPlatform, PlatformType, ScaffoldType} from '../constants';
 import {FileUtility} from '../FileUtility';
 import {TelemetryContext} from '../telemetry';
 import * as utils from '../utils';
@@ -103,7 +103,8 @@ export abstract class ArduinoDeviceBase implements Device {
 
     await utils.fetchAndExecuteTask(
         this.extensionContext, this.channel, this.telemetryContext,
-        this.deviceFolder, OperationType.Compile, constants.compileTaskName);
+        this.deviceFolder, OperationType.Compile, PlatformType.Arduino,
+        constants.compileTaskName);
     return true;
   }
 
@@ -114,7 +115,8 @@ export abstract class ArduinoDeviceBase implements Device {
     }
     await utils.fetchAndExecuteTask(
         this.extensionContext, this.channel, this.telemetryContext,
-        this.deviceFolder, OperationType.Upload, constants.uploadTaskName);
+        this.deviceFolder, OperationType.Upload, PlatformType.Arduino,
+        constants.uploadTaskName);
     return true;
   }
 

--- a/src/Models/ContainerDeviceBase.ts
+++ b/src/Models/ContainerDeviceBase.ts
@@ -128,7 +128,8 @@ export abstract class ContainerDeviceBase implements Device {
 
     await utils.fetchAndExecuteTask(
         this.extensionContext, this.channel, this.telemetryContext,
-        this.projectFolder, OperationType.Compile, constants.compileTaskName);
+        this.projectFolder, OperationType.Compile, PlatformType.EmbeddedLinux,
+        constants.compileTaskName);
     return true;
   }
 

--- a/src/Models/IoTContainerizedProject.ts
+++ b/src/Models/IoTContainerizedProject.ts
@@ -10,7 +10,7 @@ import {RemoteContainersCommands, VscodeCommands} from '../common/Commands';
 import {ConfigKey, EventNames, FileNames, ScaffoldType} from '../constants';
 import {FileUtility} from '../FileUtility';
 import {TelemetryContext, TelemetryWorker} from '../telemetry';
-import {getFirstWorkspaceFolderPath, getProjectConfig, updateProjectHostTypeConfig} from '../utils';
+import {getProjectConfig, updateProjectHostTypeConfig} from '../utils';
 
 import {Component} from './Interfaces/Component';
 import {ProjectHostType} from './Interfaces/ProjectHostType';
@@ -25,18 +25,16 @@ const raspberryPiDeviceModule =
 export class IoTContainerizedProject extends IoTWorkbenchProjectBase {
   constructor(
       context: vscode.ExtensionContext, channel: vscode.OutputChannel,
-      telemetryContext: TelemetryContext, rootFolderPath?: string) {
+      telemetryContext: TelemetryContext, rootFolderPath: string) {
     super(context, channel, telemetryContext);
     this.projectHostType = ProjectHostType.Container;
-
-    this.projectRootPath = rootFolderPath || getFirstWorkspaceFolderPath();
-    if (!this.projectRootPath) {
-      throw new Error(`Fail to get root folder.`);
+    if (!rootFolderPath) {
+      throw new Error(
+          `Fail to construct iot workspace project: root folder path is empty.`);
     }
-
+    this.projectRootPath = rootFolderPath;
     this.iotWorkbenchProjectFilePath =
         path.join(this.projectRootPath, FileNames.iotWorkbenchProjectFileName);
-
     this.telemetryContext.properties.projectHostType = this.projectHostType;
   }
 

--- a/src/ProjectEnvironmentConfiger.ts
+++ b/src/ProjectEnvironmentConfiger.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import * as utils from './utils';
+import * as path from 'path';
 
 import {TelemetryContext} from './telemetry';
 import {ScaffoldType, PlatformType} from './constants';
@@ -74,8 +75,9 @@ export class ProjectEnvironmentConfiger {
         throw new CancelOperationError(message);
       }
 
+      const projectRootPath = path.join(projectFileRootPath, '..');
       project = new ioTWorkspaceProjectModule.IoTWorkspaceProject(
-          context, channel, telemetryContext);
+          context, channel, telemetryContext, projectRootPath);
       if (!project) {
         // Ensure the project is correctly open.
         await utils.properlyOpenIoTWorkspaceProject(telemetryContext);
@@ -88,7 +90,7 @@ export class ProjectEnvironmentConfiger {
       await RemoteExtension.checkRemoteExtension();
 
       project = new ioTContainerizedProjectModule.IoTContainerizedProject(
-          context, channel, telemetryContext);
+          context, channel, telemetryContext, projectFileRootPath);
     } else {
       throw new Error('unsupported platform');
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -760,7 +760,8 @@ export async function askToOverwriteFile(fileName: string):
 export async function fetchAndExecuteTask(
     context: vscode.ExtensionContext, channel: vscode.OutputChannel,
     telemetryContext: TelemetryContext, deviceRootPath: string,
-    operationType: OperationType, taskName: string): Promise<void> {
+    operationType: OperationType, platform: PlatformType,
+    taskName: string): Promise<void> {
   const scaffoldType = ScaffoldType.Workspace;
   if (!await FileUtility.directoryExists(scaffoldType, deviceRootPath)) {
     throw new Error('Unable to find the device root folder.');
@@ -772,8 +773,8 @@ export async function fetchAndExecuteTask(
     channelShowAndAppendLine(channel, message);
 
     await askToConfigureEnvironment(
-        context, channel, telemetryContext, PlatformType.Arduino,
-        deviceRootPath, scaffoldType, operationType);
+        context, channel, telemetryContext, platform, deviceRootPath,
+        scaffoldType, operationType);
     return;
   }
 
@@ -786,8 +787,8 @@ export async function fetchAndExecuteTask(
     channelShowAndAppendLine(channel, message);
 
     await askToConfigureEnvironment(
-        context, channel, telemetryContext, PlatformType.Arduino,
-        deviceRootPath, scaffoldType, operationType);
+        context, channel, telemetryContext, platform, deviceRootPath,
+        scaffoldType, operationType);
     return;
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -609,10 +609,11 @@ export async function constructAndLoadIoTProject(
   let iotProject;
   if (projectHostType === ProjectHostType.Container) {
     iotProject = new ioTContainerizedProjectModule.IoTContainerizedProject(
-        context, channel, telemetryContext);
+        context, channel, telemetryContext, projectFileRootPath);
   } else if (projectHostType === ProjectHostType.Workspace) {
+    const projectRootPath = path.join(projectFileRootPath, '..');
     iotProject = new ioTWorkspaceProjectModule.IoTWorkspaceProject(
-        context, channel, telemetryContext);
+        context, channel, telemetryContext, projectRootPath);
   }
 
   if (isTriggeredWhenExtensionLoad) {


### PR DESCRIPTION
1. Fix auto-configure project env bug: when iot workbench project does not have ".vscode/tasks.json" file, pop up to ask to configure project environment and auto configure according to project platform type.
2. Fix workspace config file name bug: worspace config file path will be initialized in `load()` and `create()` methods respectively.
3. Fix typo