### PR TITLE
Merge v0.11.0-rc back to develop branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
     - ISPRODTAG=^v?[0-9]+\.[0-9]+\.[0-9]+$
     - ISTESTTAG=^v?[0-9]+\.[0-9]+\.[0-9]+-[rR][cC]
     - RC_EXTENSION_ID="iotdevexbuild.test-owl-project"
-    - NIGHTLY_BUILD_ID="vsciot-vscode.vscode-iot-workbench-nightly"
+    - NIGHTLY_BUILD_ID="iotdevexbuild.vscode-iot-workbench-nightly"
     # Non production situation: RC or nightly build
     - IS_TEST=true
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ env:
     - ISTESTTAG=^v?[0-9]+\.[0-9]+\.[0-9]+-[rR][cC]
     - RC_EXTENSION_ID="iotdevexbuild.test-owl-project"
     - NIGHTLY_BUILD_ID="vsciot-vscode.vscode-iot-workbench-nightly"
+    # Non production situation: RC or nightly build
+    - IS_TEST=true
 
 install:
 - sudo apt-get install libsecret-1-dev
@@ -33,7 +35,7 @@ script:
 - gts --version
 - gts check
 - node scripts/updateConfig.js
-- vsce package
+- if [[ $TRAVIS_TAG =~ $ISPRODTAG ]]; then export IS_TEST=false; fi
 - if [[ $TRAVIS_EVENT_TYPE == "cron" ]]; then
     git config --local user.name $USER_NAME &&
     git config --local user.email $USER_EMAIL &&
@@ -42,12 +44,14 @@ script:
     nightlyBuildTagExists=`git ls-remote --exit-code origin refs/tags/$TRAVIS_TAG` && nightlyBuildCommit=`git rev-list -n 1 $TRAVIS_TAG` &&
     if [[ $nightlyBuildTagExists && $nightlyBuildCommit != $TRAVIS_COMMIT ]]; then git push --delete origin $TRAVIS_TAG && git tag -f $TRAVIS_TAG && git push --tags -f; fi
   fi
+- vsce package
 - docker run -ti --rm -v $PWD:/mnt:ro dkhamsing/awesome_bot --allow-dupe --allow-redirect --skip-save-results `ls *.md`
 
 deploy:
   # deploy to github release
   - provider: releases
     api_key: $GIT_TOKEN
+    prerelease: $IS_TEST
     file_glob: true
     file: "*.vsix"
     skip_cleanup: true
@@ -57,6 +61,7 @@ deploy:
   # deploy nightly build to github release
   - provider: releases
     api_key: $GIT_TOKEN
+    prerelease: true
     overwrite: true
     file_glob: true
     file: "*.vsix"
@@ -72,7 +77,7 @@ deploy:
       tags: true
       all_branches: true
       # if it's a PROD tag (something like 1.0.0), then publish extension to market.
-      condition: "$TRAVIS_TAG =~ $ISPRODTAG"
+      condition: "$IS_PROD = true"
   # deploy test version to vscode extension market
   - provider: script
     script: yes | vsce unpublish -p $VSCE_TEST_TOKEN $RC_EXTENSION_ID && vsce publish -p $VSCE_TEST_TOKEN --packagePath *.vsix
@@ -84,7 +89,7 @@ deploy:
       condition: "$TRAVIS_TAG =~ $ISTESTTAG"
   # deploy nightly version to vscode extension market
   - provider: script
-    script: yes | vsce unpublish -p $VSCE_TOKEN $NIGHTLY_BUILD_ID && vsce publish -p $VSCE_TOKEN --packagePath *.vsix
+    script: yes | vsce unpublish -p $VSCE_TEST_TOKEN $NIGHTLY_BUILD_ID && vsce publish -p $VSCE_TEST_TOKEN --packagePath *.vsix
     skip_cleanup: true
     on:
       branch: develop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to the "vscode-iot-workbench" extension will be documented in this file.
 
+## Version 0.11.0
+
+- Release data: January 2nd, 2020
+
+## Fixed
+
+- Fix codegen error from model/interface file with UTF8-BOM encoding.[[#864](https://github.com/microsoft/vscode-iot-workbench/issues/864)]
+
+## Changes
+
+- Refine command flow of "**Azure IoT Device Workbench: Configure Development Container for CMake Project (preview)...**"
+- Refine example landing page automatically popping up behaviour.
+- Automatically configure Arduino project.
+
 ## Version 0.10.17
 
 - Release data: November 22, 2019

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/Microsoft/vscode-iot-workbench/issues"
   },
   "homepage": "https://github.com/Microsoft/vscode-iot-workbench/blob/master/README.md",
-  "version": "0.11.0-rc",
+  "version": "0.11.0",
   "publisher": "vsciot-vscode",
   "icon": "logo.png",
   "license": "SEE LICENSE IN <LICENSE>",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/Microsoft/vscode-iot-workbench/issues"
   },
   "homepage": "https://github.com/Microsoft/vscode-iot-workbench/blob/master/README.md",
-  "version": "0.10.17",
+  "version": "0.11.0-rc",
   "publisher": "vsciot-vscode",
   "icon": "logo.png",
   "license": "SEE LICENSE IN <LICENSE>",

--- a/src/DigitalTwin/CodeGeneratorCore.ts
+++ b/src/DigitalTwin/CodeGeneratorCore.ts
@@ -24,6 +24,7 @@ import {DigitalTwinUtility} from './DigitalTwinUtility';
 import {CodeGenUtility} from './DigitalTwinCodeGen/CodeGenUtility';
 import {FileUtility} from '../FileUtility';
 import {CancelOperationError} from '../CancelOperationError';
+import {Utility} from './pnp/src/common/utility';
 
 interface CodeGeneratorDownloadLocation {
   win32Md5: string;
@@ -441,8 +442,8 @@ export class CodeGeneratorCore {
     }
 
     // Parse capabilityModel name from id
-    const capabilityModel = JSON.parse(
-        fs.readFileSync(codeGenExecutionInfo.capabilityModelFilePath, 'utf8'));
+    const capabilityModel = await Utility.getJsonContent(
+        codeGenExecutionInfo.capabilityModelFilePath);
     const capabilityModelId = capabilityModel['@id'];
 
     await vscode.window.withProgress(

--- a/src/Models/IoTWorkspaceProject.ts
+++ b/src/Models/IoTWorkspaceProject.ts
@@ -61,6 +61,8 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
   }
 
   async load(scaffoldType: ScaffoldType, initLoad = false): Promise<void> {
+    this.validateProjectRootPath(scaffoldType);
+
     // Init device root path
     const devicePath = ConfigHandler.get<string>(ConfigKey.devicePath);
     if (!devicePath) {
@@ -80,15 +82,7 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
         scaffoldType, this.iotWorkbenchProjectFilePath, this.projectHostType);
 
     // Init workspace config file
-    const workspaceFile = getWorkspaceFile(this.projectRootPath);
-    if (workspaceFile) {
-      this.workspaceConfigFilePath =
-          path.join(this.projectRootPath, workspaceFile);
-    } else {
-      throw new Error(
-          `Fail to load iot workspace project: Cannot find workspace file under project root path: ${
-              this.projectRootPath}.`);
-    }
+    this.loadAndInitWorkspaceConfigFilePath(scaffoldType);
 
     // Send load project event telemetry only if the IoT project is loaded
     // when VS Code opens.
@@ -185,6 +179,8 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
   async openProject(
       scaffoldType: ScaffoldType, openInNewWindow: boolean,
       openScenario: OpenScenario): Promise<void> {
+    this.loadAndInitWorkspaceConfigFilePath(scaffoldType);
+
     if (!await FileUtility.fileExists(
             scaffoldType, this.workspaceConfigFilePath)) {
       throw new Error(`Workspace config file ${
@@ -484,6 +480,21 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
       }
       default:
         break;
+    }
+  }
+
+  // Init workspace config file path at load time
+  private async loadAndInitWorkspaceConfigFilePath(scaffoldType: ScaffoldType) {
+    this.validateProjectRootPath(scaffoldType);
+
+    const workspaceFile = getWorkspaceFile(this.projectRootPath);
+    if (workspaceFile) {
+      this.workspaceConfigFilePath =
+          path.join(this.projectRootPath, workspaceFile);
+    } else {
+      throw new Error(
+          `Fail to init iot project workspace file path: Cannot find workspace file under project root path: ${
+              this.projectRootPath}.`);
     }
   }
 }

--- a/src/Models/IoTWorkspaceProject.ts
+++ b/src/Models/IoTWorkspaceProject.ts
@@ -148,7 +148,7 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
         folderName.deviceDefaultFolderName;
 
     // Create azure components
-    this.createAzureComponentsWithProjectType(
+    await this.createAzureComponentsWithProjectType(
         projectType, createTimeScaffoldType, workspace);
 
     // Update workspace config to workspace config file

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -123,12 +123,14 @@ export interface FolderQuickPickItem<T = undefined> extends
  * Check there is workspace opened in VS Code
  * and get the first workspace folder path.
  */
-export function getFirstWorkspaceFolderPath(): string {
+export function getFirstWorkspaceFolderPath(showWarningMessage = true): string {
   if (!(vscode.workspace.workspaceFolders &&
         vscode.workspace.workspaceFolders.length > 0) ||
       !vscode.workspace.workspaceFolders[0].uri.fsPath) {
-    vscode.window.showWarningMessage(
-        'You have not yet opened a folder in Visual Studio Code. Please select a folder first.');
+    if (showWarningMessage) {
+      vscode.window.showWarningMessage(
+          'You have not yet opened a folder in Visual Studio Code. Please select a folder first.');
+    }
     return '';
   }
 
@@ -608,7 +610,7 @@ export async function constructAndLoadIoTProject(
     telemetryContext: TelemetryContext, isTriggeredWhenExtensionLoad = false) {
   const scaffoldType = ScaffoldType.Workspace;
 
-  const projectFileRootPath = getFirstWorkspaceFolderPath();
+  const projectFileRootPath = getFirstWorkspaceFolderPath(false);
   const projectHostType = await IoTWorkbenchProjectBase.getProjectType(
       scaffoldType, projectFileRootPath);
 


### PR DESCRIPTION
1. Tag nightly build and rc version as `pre-release` in release page.
2. Update version number to `0.110-rc`
3. Update nightly build vsce token as iotdevexbuild  vsce token (`VSCE_TEST_TOKEN`).
4. Ignore warning message when init load.