### PR TITLE
Remove Travis CI notification

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -94,10 +94,3 @@ deploy:
     on:
       branch: develop
       condition: "$TRAVIS_EVENT_TYPE = 'cron'"
-
-notifications:
-  email:
-    recipients:
-      - ddexp@microsoft.com
-    on_success: always
-    on_failure: always


### PR DESCRIPTION
Temperately remove travis ci emial notification and will add it when applying azure pipeline.