### PR TITLE
Fix foreach bug

### DIFF
--- a/src/Models/AZ3166Device.ts
+++ b/src/Models/AZ3166Device.ts
@@ -134,10 +134,6 @@ export class AZ3166Device extends ArduinoDeviceBase {
     return version;
   }
 
-  async checkPrerequisites(): Promise<boolean> {
-    return super.checkPrerequisites();
-  }
-
   async create(): Promise<void> {
     this.createCore();
   }

--- a/src/Models/ArduinoDeviceBase.ts
+++ b/src/Models/ArduinoDeviceBase.ts
@@ -23,6 +23,7 @@ import { OTA } from "./OTA";
 import { DirectoryNotFoundError } from "../common/Error/OperationFailedErrors/DirectoryNotFoundError";
 import { FileNotFoundError } from "../common/Error/OperationFailedErrors/FileNotFound";
 import { checkExtensionAvailable } from "./Apis";
+import { DependentExtensionNotFoundError } from "../common/Error/OperationFailedErrors/DependentExtensionNotFoundError";
 import { ExtensionName } from "./Interfaces/Api";
 
 const constants = {
@@ -84,8 +85,11 @@ export abstract class ArduinoDeviceBase implements Device {
     return await checkExtensionAvailable(ExtensionName.Arduino);
   }
 
-  async checkPrerequisites(): Promise<boolean> {
-    return await ArduinoDeviceBase.isAvailable();
+  async checkPrerequisites(operation: string): Promise<void> {
+    const res = await ArduinoDeviceBase.isAvailable();
+    if (!res) {
+      throw new DependentExtensionNotFoundError(operation, ExtensionName.Arduino);
+    }
   }
 
   async compile(): Promise<boolean> {

--- a/src/Models/AzureFunctions.ts
+++ b/src/Models/AzureFunctions.ts
@@ -106,12 +106,11 @@ export class AzureFunctions implements Component, Provisionable, Deployable {
     return await checkExtensionAvailable(ExtensionName.AzureFunctions);
   }
 
-  async checkPrerequisites(): Promise<boolean> {
+  async checkPrerequisites(operation: string): Promise<void> {
     const isFunctionsExtensionAvailable = await AzureFunctions.isAvailable();
     if (!isFunctionsExtensionAvailable) {
-      return false;
+      throw new DependentExtensionNotFoundError(operation, ExtensionName.AzureFunctions);
     }
-    return true;
   }
 
   async load(): Promise<void> {

--- a/src/Models/ContainerDeviceBase.ts
+++ b/src/Models/ContainerDeviceBase.ts
@@ -66,8 +66,8 @@ export abstract class ContainerDeviceBase implements Device {
     return this.componentType;
   }
 
-  async checkPrerequisites(): Promise<boolean> {
-    return true;
+  async checkPrerequisites(): Promise<void> {
+    // Do nothing.
   }
 
   async load(): Promise<void> {

--- a/src/Models/Esp32Device.ts
+++ b/src/Models/Esp32Device.ts
@@ -93,10 +93,6 @@ export class Esp32Device extends ArduinoDeviceBase {
     this.azureConfigFileHandler = new AzureConfigFileHandler(projectFolder);
   }
 
-  async checkPrerequisites(): Promise<boolean> {
-    return super.checkPrerequisites();
-  }
-
   async create(): Promise<void> {
     this.createCore();
   }

--- a/src/Models/Interfaces/Component.ts
+++ b/src/Models/Interfaces/Component.ts
@@ -13,6 +13,6 @@ export interface Component {
   id: string;
   load(): Promise<void>;
   create(): Promise<void>;
-  checkPrerequisites(): Promise<boolean>;
+  checkPrerequisites(operation: string): Promise<void>;
   getComponentType(): ComponentType;
 }

--- a/src/Models/IoTContainerizedProject.ts
+++ b/src/Models/IoTContainerizedProject.ts
@@ -10,7 +10,6 @@ import { RemoteContainersCommands, VscodeCommands } from "../common/Commands";
 import { ArgumentEmptyOrNullError } from "../common/Error/OperationFailedErrors/ArgumentEmptyOrNullError";
 import { TypeNotSupportedError } from "../common/Error/SystemErrors/TypeNotSupportedError";
 import { OperationCanceledError } from "../common/Error/OperationCanceledError";
-import { OperationFailedError } from "../common/Error/OperationFailedErrors/OperationFailedError";
 import { ConfigKey, EventNames, FileNames, ScaffoldType } from "../constants";
 import { FileUtility } from "../FileUtility";
 import { TelemetryContext, TelemetryWorker } from "../telemetry";
@@ -105,16 +104,11 @@ export class IoTContainerizedProject extends IoTWorkbenchProjectBase {
     await FileUtility.writeJsonFile(createTimeScaffoldType, this.iotWorkbenchProjectFilePath, projectConfig);
 
     // Check components prerequisites
-    this.componentList.forEach(async item => {
-      const res = await item.checkPrerequisites();
-      if (!res) {
-        throw new OperationFailedError(
-          "create component for iot containerized project",
-          "component prerequisites are not met.",
-          "Please check out error message in the output window."
-        );
-      }
-    });
+    await Promise.all(
+      this.componentList.map(async component => {
+        await component.checkPrerequisites("create iot containerized project");
+      })
+    );
 
     // Create components
     try {

--- a/src/Models/IoTContainerizedProject.ts
+++ b/src/Models/IoTContainerizedProject.ts
@@ -75,7 +75,7 @@ export class IoTContainerizedProject extends IoTWorkbenchProjectBase {
     openInNewWindow: boolean
   ): Promise<void> {
     // Can only create project locally
-    await RemoteExtension.checkRemoteExtension();
+    await RemoteExtension.checkRemoteExtension("create iot containerized project");
 
     const createTimeScaffoldType = ScaffoldType.Local;
 
@@ -169,7 +169,7 @@ export class IoTContainerizedProject extends IoTWorkbenchProjectBase {
       throw new DirectoryNotFoundError("open folder in container", `folder path ${folderPath}`, "");
     }
 
-    await RemoteExtension.checkRemoteExtension();
+    await RemoteExtension.checkRemoteExtension("open folder in container");
 
     await vscode.commands.executeCommand(RemoteContainersCommands.OpenFolder, vscode.Uri.file(folderPath));
   }

--- a/src/Models/IoTHub.ts
+++ b/src/Models/IoTHub.ts
@@ -42,8 +42,8 @@ export class IoTHub implements Component, Provisionable {
     return this.componentType;
   }
 
-  async checkPrerequisites(): Promise<boolean> {
-    return true;
+  async checkPrerequisites(): Promise<void> {
+    // Do nothing.
   }
 
   async load(): Promise<void> {

--- a/src/Models/IoTHubDevice.ts
+++ b/src/Models/IoTHubDevice.ts
@@ -100,8 +100,8 @@ export class IoTHubDevice implements Component, Provisionable {
     return this.componentType;
   }
 
-  async checkPrerequisites(): Promise<boolean> {
-    return true;
+  async checkPrerequisites(): Promise<void> {
+    // Do nothing.
   }
 
   async load(): Promise<void> {

--- a/src/Models/IoTWorkbenchProjectBase.ts
+++ b/src/Models/IoTWorkbenchProjectBase.ts
@@ -116,10 +116,7 @@ export abstract class IoTWorkbenchProjectBase {
   async compile(): Promise<boolean> {
     for (const item of this.componentList) {
       if (this.canCompile(item)) {
-        const isPrerequisitesAchieved = await item.checkPrerequisites();
-        if (!isPrerequisitesAchieved) {
-          return false;
-        }
+        await item.checkPrerequisites("compile device code");
 
         const res = await item.compile();
         if (!res) {
@@ -133,11 +130,7 @@ export abstract class IoTWorkbenchProjectBase {
   async upload(): Promise<boolean> {
     for (const item of this.componentList) {
       if (this.canUpload(item)) {
-        const isPrerequisitesAchieved = await item.checkPrerequisites();
-        if (!isPrerequisitesAchieved) {
-          return false;
-        }
-
+        await item.checkPrerequisites("upload device code");
         const res = await item.upload();
         if (!res) {
           vscode.window.showErrorMessage("Unable to upload the sketch, please check output window for detail.");
@@ -151,11 +144,7 @@ export abstract class IoTWorkbenchProjectBase {
     const provisionItemList: string[] = [];
     for (const item of this.componentList) {
       if (this.canProvision(item)) {
-        const isPrerequisitesAchieved = await item.checkPrerequisites();
-        if (!isPrerequisitesAchieved) {
-          return false;
-        }
-
+        await item.checkPrerequisites("provision");
         provisionItemList.push(item.name);
       }
     }
@@ -221,11 +210,7 @@ export abstract class IoTWorkbenchProjectBase {
     const deployItemList: string[] = [];
     for (const item of this.componentList) {
       if (this.canDeploy(item)) {
-        const isPrerequisitesAchieved = await item.checkPrerequisites();
-        if (!isPrerequisitesAchieved) {
-          return;
-        }
-
+        await item.checkPrerequisites("deploy device code");
         deployItemList.push(item.name);
       }
     }

--- a/src/Models/IoTWorkspaceProject.ts
+++ b/src/Models/IoTWorkspaceProject.ts
@@ -100,9 +100,11 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
     await this.initAzureConfig(scaffoldType);
 
     // Check components prerequisites
-    this.componentList.forEach(async item => {
-      await item.checkPrerequisites();
-    });
+    await Promise.all(
+      this.componentList.map(async component => {
+        await component.checkPrerequisites("load project");
+      })
+    );
   }
 
   async create(
@@ -151,12 +153,11 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
     await FileUtility.writeJsonFile(createTimeScaffoldType, this.workspaceConfigFilePath, workspace);
 
     // Check components prerequisites
-    this.componentList.forEach(async item => {
-      const res = await item.checkPrerequisites();
-      if (!res) {
-        return;
-      }
-    });
+    await Promise.all(
+      this.componentList.map(async component => {
+        await component.checkPrerequisites("create project");
+      })
+    );
 
     // Create components
     try {

--- a/src/Models/RemoteExtension.ts
+++ b/src/Models/RemoteExtension.ts
@@ -2,9 +2,9 @@ import * as vscode from "vscode";
 import { ExtensionName } from "./Interfaces/Api";
 import { WorkbenchExtension } from "../WorkbenchExtension";
 import { RemoteEnvNotSupportedError } from "../common/Error/OperationFailedErrors/RemoteEnvNotSupportedError";
-import { OperationCanceledError } from "../common/Error/OperationCanceledError";
 import { OperationFailedError } from "../common/Error/OperationFailedErrors/OperationFailedError";
 import { checkExtensionAvailable } from "./Apis";
+import { DependentExtensionNotFoundError } from "../common/Error/OperationFailedErrors/DependentExtensionNotFoundError";
 
 export class RemoteExtension {
   static isRemote(context: vscode.ExtensionContext): boolean {
@@ -25,12 +25,10 @@ export class RemoteExtension {
     return await checkExtensionAvailable(ExtensionName.Remote);
   }
 
-  static async checkRemoteExtension(): Promise<void> {
+  static async checkRemoteExtension(operation: string): Promise<void> {
     const res = await RemoteExtension.isAvailable();
     if (!res) {
-      throw new OperationCanceledError(
-        `Remote extension is not available. Please install ${ExtensionName.Remote} first.`
-      );
+      throw new DependentExtensionNotFoundError(operation, ExtensionName.Remote);
     }
   }
 

--- a/src/ProjectEnvironmentConfiger.ts
+++ b/src/ProjectEnvironmentConfiger.ts
@@ -94,7 +94,7 @@ export class ProjectEnvironmentConfiger {
       // project
       await configExternalCMakeProjectToIoTContainerProject(scaffoldType);
 
-      await RemoteExtension.checkRemoteExtension();
+      await RemoteExtension.checkRemoteExtension("configure project environment");
 
       project = new ioTContainerizedProjectModule.IoTContainerizedProject(
         context,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -354,7 +354,7 @@ export async function askAndOpenInRemote(operation: OperationType, telemetryCont
 
   if (result === DialogResponses.yes) {
     telemetryContext.properties.errorMessage = `${operation} operation failed and user reopens project in container.`;
-    await RemoteExtension.checkRemoteExtension();
+    await RemoteExtension.checkRemoteExtension("open project in container");
 
     await vscode.commands.executeCommand(RemoteContainersCommands.ReopenInContainer);
   } else {


### PR DESCRIPTION
In TypeScript, usage of `foreach` should be careful. If function inside `foreach` is asynchronous, `foreach` will not wait until all items are finished. (See [Reference](https://lavrton.com/javascript-loops-how-to-handle-async-await-6252dd3c795/)).

this PR:
1. Fix foreach with async functions. Change to `Promise.all()`. Fix the [bug](https://dev.azure.com/mseng/VSIoT/_workitems/edit/1679203).
2. Change `checkPrerequisite()` function to return `Promise<void>` instead of `Promise<boolean>`. User will get error message when operation failed for not finding dependent extensions.