### PR TITLE
Fix Arduino project lazy creation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2069,8 +2069,7 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -2091,14 +2090,12 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -2113,20 +2110,17 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -2243,8 +2237,7 @@
             "inherits": {
               "version": "2.0.4",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -2256,7 +2249,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -2271,7 +2263,6 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -2279,14 +2270,12 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "minipass": {
               "version": "2.9.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -2305,7 +2294,6 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -2395,8 +2383,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -2408,7 +2395,6 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -2494,8 +2480,7 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -2531,7 +2516,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -2551,7 +2535,6 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -2595,14 +2578,12 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "yallist": {
               "version": "3.1.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             }
           }
         },

--- a/src/DigitalTwin/CodeGeneratorCore.ts
+++ b/src/DigitalTwin/CodeGeneratorCore.ts
@@ -97,7 +97,7 @@ export class CodeGeneratorCore {
   ): Promise<void> {
     RemoteExtension.ensureLocalBeforeRunCommand("generate device code stub", context);
 
-    const rootPath = utils.getFirstWorkspaceFolderPath();
+    const rootPath = utils.getProjectDeviceRootPath();
     if (!rootPath) {
       throw new WorkspaceNotOpenError("generate device code stub");
     }

--- a/src/Models/Apis.ts
+++ b/src/Models/Apis.ts
@@ -15,7 +15,6 @@ export function getExtension(name: ExtensionName): any {
     if (extension) {
       switch (name) {
         case ExtensionName.AzureAccount:
-        case ExtensionName.AzureFunctions:
         case ExtensionName.Toolkit:
           return extension.exports ? extension.exports : undefined;
         default:

--- a/src/Models/ArduinoDeviceBase.ts
+++ b/src/Models/ArduinoDeviceBase.ts
@@ -228,7 +228,7 @@ export abstract class ArduinoDeviceBase implements Device {
       throw new WorkspaceConfigNotFoundError(ConfigKey.devicePath);
     }
 
-    const rootPath = utils.getFirstWorkspaceFolderPath();
+    const rootPath = utils.getProjectDeviceRootPath();
     if (!rootPath) {
       throw new WorkspaceNotOpenError("generate CRC");
     }

--- a/src/Models/AzureFunctions.ts
+++ b/src/Models/AzureFunctions.ts
@@ -334,10 +334,9 @@ export class AzureFunctions implements Component, Provisionable, Deployable {
   async updateConfigSettings(type: ScaffoldType, componentInfo?: ComponentInfo): Promise<void> {
     const componentIndex = await this.azureConfigFileHandler.getComponentIndexById(type, this.id);
     if (componentIndex > -1) {
-      if (!componentInfo) {
-        throw new ArgumentEmptyOrNullError("AzureFunctions updateConfigSettings", `componentInfo`);
+      if (componentInfo) {
+        await this.azureConfigFileHandler.updateComponent(type, componentIndex, componentInfo);
       }
-      await this.azureConfigFileHandler.updateComponent(type, componentIndex, componentInfo);
     } else {
       const newAzureFunctionsConfig: AzureComponentConfig = {
         id: this.id,

--- a/src/Models/AzureFunctions.ts
+++ b/src/Models/AzureFunctions.ts
@@ -334,9 +334,10 @@ export class AzureFunctions implements Component, Provisionable, Deployable {
   async updateConfigSettings(type: ScaffoldType, componentInfo?: ComponentInfo): Promise<void> {
     const componentIndex = await this.azureConfigFileHandler.getComponentIndexById(type, this.id);
     if (componentIndex > -1) {
-      if (componentInfo) {
-        await this.azureConfigFileHandler.updateComponent(type, componentIndex, componentInfo);
+      if (!componentInfo) {
+        throw new ArgumentEmptyOrNullError("update config settings of IoTHub", "component info");
       }
+      await this.azureConfigFileHandler.updateComponent(type, componentIndex, componentInfo);
     } else {
       const newAzureFunctionsConfig: AzureComponentConfig = {
         id: this.id,

--- a/src/Models/IoTContainerizedProject.ts
+++ b/src/Models/IoTContainerizedProject.ts
@@ -48,7 +48,7 @@ export class IoTContainerizedProject extends IoTWorkbenchProjectBase {
   }
 
   async load(scaffoldType: ScaffoldType, initLoad = false): Promise<void> {
-    this.validateProjectRootPath("load project", scaffoldType);
+    await this.validateProjectRootPathExists("load project", scaffoldType);
 
     // 1. Update iot workbench project file.
     await updateProjectHostTypeConfig(scaffoldType, this.iotWorkbenchProjectFilePath, this.projectHostType);
@@ -129,7 +129,7 @@ export class IoTContainerizedProject extends IoTWorkbenchProjectBase {
    * If yes, open project in container. If not, stay local.
    */
   async openProject(scaffoldType: ScaffoldType, openInNewWindow: boolean, openScenario: OpenScenario): Promise<void> {
-    this.validateProjectRootPath("open project", scaffoldType);
+    await this.validateProjectRootPathExists("open project", scaffoldType);
 
     // 1. Ask to customize
     let openInContainer = false;
@@ -186,7 +186,7 @@ export class IoTContainerizedProject extends IoTWorkbenchProjectBase {
     scaffoldType: ScaffoldType,
     templateFilesInfo?: TemplateFileInfo[]
   ): Promise<void> {
-    this.validateProjectRootPath("initialize device", scaffoldType);
+    await this.validateProjectRootPathExists("initialize device", scaffoldType);
 
     let device: Component;
     if (boardId === raspberryPiDeviceModule.RaspberryPiDevice.boardId) {

--- a/src/Models/IoTHub.ts
+++ b/src/Models/IoTHub.ts
@@ -15,7 +15,6 @@ import { AzureUtility } from "./AzureUtility";
 import { ExtensionName } from "./Interfaces/Api";
 import { Component, ComponentType } from "./Interfaces/Component";
 import { Provisionable } from "./Interfaces/Provisionable";
-import { ArgumentEmptyOrNullError } from "../common/Error/OperationFailedErrors/ArgumentEmptyOrNullError";
 
 export class IoTHub implements Component, Provisionable {
   dependencies: DependencyConfig[] = [];
@@ -155,10 +154,9 @@ export class IoTHub implements Component, Provisionable {
     const iotHubComponentIndex = await this.azureConfigFileHandler.getComponentIndexById(type, this.id);
 
     if (iotHubComponentIndex > -1) {
-      if (!componentInfo) {
-        throw new ArgumentEmptyOrNullError("IoTHub updateConfigSettings", "componentInfo");
+      if (componentInfo) {
+        await this.azureConfigFileHandler.updateComponent(type, iotHubComponentIndex, componentInfo);
       }
-      await this.azureConfigFileHandler.updateComponent(type, iotHubComponentIndex, componentInfo);
     } else {
       const newIoTHubConfig: AzureComponentConfig = {
         id: this.id,

--- a/src/Models/IoTHub.ts
+++ b/src/Models/IoTHub.ts
@@ -15,6 +15,7 @@ import { AzureUtility } from "./AzureUtility";
 import { ExtensionName } from "./Interfaces/Api";
 import { Component, ComponentType } from "./Interfaces/Component";
 import { Provisionable } from "./Interfaces/Provisionable";
+import { ArgumentEmptyOrNullError } from "../common/Error/OperationFailedErrors/ArgumentEmptyOrNullError";
 
 export class IoTHub implements Component, Provisionable {
   dependencies: DependencyConfig[] = [];
@@ -154,9 +155,10 @@ export class IoTHub implements Component, Provisionable {
     const iotHubComponentIndex = await this.azureConfigFileHandler.getComponentIndexById(type, this.id);
 
     if (iotHubComponentIndex > -1) {
-      if (componentInfo) {
-        await this.azureConfigFileHandler.updateComponent(type, iotHubComponentIndex, componentInfo);
+      if (!componentInfo) {
+        throw new ArgumentEmptyOrNullError("update config settings of azure functions", "component info");
       }
+      await this.azureConfigFileHandler.updateComponent(type, iotHubComponentIndex, componentInfo);
     } else {
       const newIoTHubConfig: AzureComponentConfig = {
         id: this.id,

--- a/src/Models/IoTHubDevice.ts
+++ b/src/Models/IoTHubDevice.ts
@@ -21,7 +21,6 @@ import { ExtensionName } from "./Interfaces/Api";
 import { Component, ComponentType } from "./Interfaces/Component";
 import { Provisionable } from "./Interfaces/Provisionable";
 import { AzureConfigNotFoundError } from "../common/Error/SystemErrors/AzureConfigNotFoundErrors";
-import { ArgumentEmptyOrNullError } from "../common/Error/OperationFailedErrors/ArgumentEmptyOrNullError";
 
 async function getDeviceNumber(iotHubConnectionString: string): Promise<number> {
   return new Promise((resolve: (value: number) => void, reject: (error: Error) => void) => {
@@ -185,10 +184,9 @@ export class IoTHubDevice implements Component, Provisionable {
   async updateConfigSettings(type: ScaffoldType, componentInfo?: ComponentInfo): Promise<void> {
     const iotHubComponentIndex = await this.azureConfigFileHandler.getComponentIndexById(type, this.id);
     if (iotHubComponentIndex > -1) {
-      if (!componentInfo) {
-        throw new ArgumentEmptyOrNullError("IoTHubDevice updateConfigSettings", "componentInfo");
+      if (componentInfo) {
+        await this.azureConfigFileHandler.updateComponent(type, iotHubComponentIndex, componentInfo);
       }
-      await this.azureConfigFileHandler.updateComponent(type, iotHubComponentIndex, componentInfo);
     } else {
       const newIotHubConfig: AzureComponentConfig = {
         id: this.id,

--- a/src/Models/IoTHubDevice.ts
+++ b/src/Models/IoTHubDevice.ts
@@ -21,6 +21,7 @@ import { ExtensionName } from "./Interfaces/Api";
 import { Component, ComponentType } from "./Interfaces/Component";
 import { Provisionable } from "./Interfaces/Provisionable";
 import { AzureConfigNotFoundError } from "../common/Error/SystemErrors/AzureConfigNotFoundErrors";
+import { ArgumentEmptyOrNullError } from "../common/Error/OperationFailedErrors/ArgumentEmptyOrNullError";
 
 async function getDeviceNumber(iotHubConnectionString: string): Promise<number> {
   return new Promise((resolve: (value: number) => void, reject: (error: Error) => void) => {
@@ -184,9 +185,10 @@ export class IoTHubDevice implements Component, Provisionable {
   async updateConfigSettings(type: ScaffoldType, componentInfo?: ComponentInfo): Promise<void> {
     const iotHubComponentIndex = await this.azureConfigFileHandler.getComponentIndexById(type, this.id);
     if (iotHubComponentIndex > -1) {
-      if (componentInfo) {
-        await this.azureConfigFileHandler.updateComponent(type, iotHubComponentIndex, componentInfo);
+      if (!componentInfo) {
+        throw new ArgumentEmptyOrNullError("update config settings of IoTHub device", "component info");
       }
+      await this.azureConfigFileHandler.updateComponent(type, iotHubComponentIndex, componentInfo);
     } else {
       const newIotHubConfig: AzureComponentConfig = {
         id: this.id,

--- a/src/Models/IoTWorkbenchProjectBase.ts
+++ b/src/Models/IoTWorkbenchProjectBase.ts
@@ -306,7 +306,7 @@ export abstract class IoTWorkbenchProjectBase {
    * Validate whether project root path exists. If not, throw error.
    * @param scaffoldType scaffold type
    */
-  async validateProjectRootPath(operation: string, scaffoldType: ScaffoldType): Promise<void> {
+  async validateProjectRootPathExists(operation: string, scaffoldType: ScaffoldType): Promise<void> {
     if (!(await FileUtility.directoryExists(scaffoldType, this.projectRootPath))) {
       throw new DirectoryNotFoundError(
         operation,

--- a/src/Models/IoTWorkspaceProject.ts
+++ b/src/Models/IoTWorkspaceProject.ts
@@ -106,7 +106,7 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
     );
 
     // Init and load azure components
-    await this.loadAzureConfigAndInitAzureComponents(scaffoldType);
+    await this.loadAzureConfigAndComponents(scaffoldType);
 
     // Check components prerequisites
     await Promise.all(
@@ -297,7 +297,7 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
    * @param scaffoldType scaffold type
    * @param componentConfigs azure component configs
    */
-  private async loadAzureComponentsWithConfig(componentConfigs: AzureComponentConfig[]): Promise<void> {
+  private async loadAzureComponentsByConfig(componentConfigs: AzureComponentConfig[]): Promise<void> {
     for (const componentConfig of componentConfigs) {
       switch (componentConfig.type) {
         case ComponentType.IoTHub: {
@@ -349,7 +349,7 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
    * Load project config and init Azure components.
    * @param scaffoldType scaffold type
    */
-  private async loadAzureConfigAndInitAzureComponents(scaffoldType: ScaffoldType): Promise<void> {
+  private async loadAzureConfigAndComponents(scaffoldType: ScaffoldType): Promise<void> {
     const azureConfigFileHandler = new azureComponentConfigModule.AzureConfigFileHandler(this.projectRootPath);
     await azureConfigFileHandler.createIfNotExists(scaffoldType);
 
@@ -359,7 +359,7 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
       // Support backward compact
       this.initAzureComponentsWithoutConfig(scaffoldType);
     } else {
-      await this.loadAzureComponentsWithConfig(componentConfigs);
+      await this.loadAzureComponentsByConfig(componentConfigs);
     }
   }
 

--- a/src/Models/IoTWorkspaceProject.ts
+++ b/src/Models/IoTWorkspaceProject.ts
@@ -62,7 +62,7 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
   }
 
   async load(scaffoldType: ScaffoldType, initLoad = false): Promise<void> {
-    this.validateProjectRootPath("load project", scaffoldType);
+    await this.validateProjectRootPathExists("load project", scaffoldType);
 
     // Init device root path
     const devicePath = ConfigHandler.get<string>(ConfigKey.devicePath);
@@ -82,8 +82,8 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
     this.iotWorkbenchProjectFilePath = path.join(this.deviceRootPath, FileNames.iotWorkbenchProjectFileName);
     await updateProjectHostTypeConfig(scaffoldType, this.iotWorkbenchProjectFilePath, this.projectHostType);
 
-    // Init workspace config file
-    this.loadAndInitWorkspaceConfigFilePath(scaffoldType);
+    // Init workspace config file path
+    await this.loadWorkspaceConfigFilePath(scaffoldType);
 
     // Send load project event telemetry only if the IoT project is loaded
     // when VS Code opens.
@@ -95,9 +95,18 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
     if (!boardId) {
       throw new WorkspaceConfigNotFoundError(ConfigKey.boardId);
     }
-    await this.initDevice(boardId, scaffoldType);
 
-    await this.initAzureConfig(scaffoldType);
+    // Init device component
+    this.initDeviceComponents(boardId);
+    // Load device component
+    await Promise.all(
+      this.componentList.map(async component => {
+        await component.load();
+      })
+    );
+
+    // Init and load azure components
+    await this.loadAzureConfigAndInitAzureComponents(scaffoldType);
 
     // Check components prerequisites
     await Promise.all(
@@ -114,56 +123,50 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
     openInNewWindow: boolean
   ): Promise<void> {
     const createTimeScaffoldType = ScaffoldType.Local;
+    const workspace: Workspace = { folders: [], settings: {} };
 
     // Init device root path
     this.deviceRootPath = path.join(this.projectRootPath, IoTWorkspaceProject.folderName.deviceDefaultFolderName);
-    if (!(await FileUtility.directoryExists(createTimeScaffoldType, this.deviceRootPath))) {
-      await FileUtility.mkdirRecursively(createTimeScaffoldType, this.deviceRootPath);
-    }
     // Init iot workbench project file path
     this.iotWorkbenchProjectFilePath = path.join(this.deviceRootPath, FileNames.iotWorkbenchProjectFileName);
-    // Init workspace config file
-    this.workspaceConfigFilePath = path.join(
-      this.projectRootPath,
-      `${path.basename(this.projectRootPath)}${FileNames.workspaceExtensionName}`
-    );
 
-    // Update iot workbench project file.
-    await updateProjectHostTypeConfig(createTimeScaffoldType, this.iotWorkbenchProjectFilePath, this.projectHostType);
+    // Init device components
+    this.initDeviceComponents(boardId, templateFilesInfo);
+    // init azure components
+    this.initAzureComponents(projectType, workspace);
 
-    const workspace: Workspace = { folders: [], settings: {} };
-
-    // Init device
-    await this.initDevice(boardId, createTimeScaffoldType, templateFilesInfo);
     workspace.folders.push({ path: IoTWorkspaceProject.folderName.deviceDefaultFolderName });
     workspace.settings[`IoTWorkbench.${ConfigKey.boardId}`] = boardId;
     workspace.settings[`IoTWorkbench.${ConfigKey.devicePath}`] = IoTWorkspaceProject.folderName.deviceDefaultFolderName;
 
-    // Create azure components
-    await this.createAzureComponentsWithProjectType(projectType, createTimeScaffoldType, workspace);
-
-    // Update workspace config to workspace config file
-    if (!this.workspaceConfigFilePath) {
-      throw new ArgumentEmptyOrNullError(
-        "update workspace config file",
-        "workspace configuration file path",
-        "Please initialize the project first."
-      );
-    }
-    await FileUtility.writeJsonFile(createTimeScaffoldType, this.workspaceConfigFilePath, workspace);
-
-    // Check components prerequisites
+    // Check components' prerequisites
     await Promise.all(
       this.componentList.map(async component => {
         await component.checkPrerequisites("create project");
       })
     );
 
+    // Create azure config file
+    const azureConfigFileHandler = new azureComponentConfigModule.AzureConfigFileHandler(this.projectRootPath);
+    await azureConfigFileHandler.createIfNotExists(createTimeScaffoldType);
+
+    // Update iot workbench project file
+    await updateProjectHostTypeConfig(createTimeScaffoldType, this.iotWorkbenchProjectFilePath, this.projectHostType);
+
+    // Create workspace config file
+    this.workspaceConfigFilePath = path.join(
+      this.projectRootPath,
+      `${path.basename(this.projectRootPath)}${FileNames.workspaceExtensionName}`
+    );
+    await FileUtility.writeJsonFile(createTimeScaffoldType, this.workspaceConfigFilePath, workspace);
+
     // Create components
     try {
-      for (let i = 0; i < this.componentList.length; i++) {
-        await this.componentList[i].create();
-      }
+      await Promise.all(
+        this.componentList.map(async component => {
+          await component.create();
+        })
+      );
     } catch (error) {
       fs.removeSync(this.projectRootPath);
       throw error;
@@ -174,7 +177,7 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
   }
 
   async openProject(scaffoldType: ScaffoldType, openInNewWindow: boolean, openScenario: OpenScenario): Promise<void> {
-    this.loadAndInitWorkspaceConfigFilePath(scaffoldType);
+    this.loadWorkspaceConfigFilePath(scaffoldType);
 
     if (!(await FileUtility.fileExists(scaffoldType, this.workspaceConfigFilePath))) {
       throw new FileNotFoundError(
@@ -203,19 +206,15 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
   }
 
   /**
-   * Create and load device component according to board id.
-   * Push device to component list.
+   * Init device components according to board id.
+   * Update component list with device.
    * @param boardId board id
    * @param scaffoldType scaffold type
    * @param templateFilesInfo template files info to scaffold files for device
    */
-  private async initDevice(
-    boardId: string,
-    scaffoldType: ScaffoldType,
-    templateFilesInfo?: TemplateFileInfo[]
-  ): Promise<void> {
-    if (!(await FileUtility.directoryExists(scaffoldType, this.deviceRootPath))) {
-      throw new DirectoryNotFoundError(
+  private initDeviceComponents(boardId: string, templateFilesInfo?: TemplateFileInfo[]): void {
+    if (!this.deviceRootPath) {
+      throw new ArgumentEmptyOrNullError(
         "initialize device",
         `device root path: ${this.deviceRootPath}`,
         "Please initialize the project first."
@@ -245,24 +244,22 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
 
     if (device) {
       this.componentList.push(device);
-      await device.load();
     }
   }
 
   /**
    * For backward compatibility.
    * If no azure components configs found in azure config files,
-   * init azure components and update azure config files.
+   * init azure components and update component lists and azure configs.
    * @param scaffoldType Scaffold type
    */
   private async initAzureComponentsWithoutConfig(scaffoldType: ScaffoldType): Promise<void> {
-    this.validateProjectRootPath("init azure components without configuration", scaffoldType);
-
+    // Init iotHub
     const iotHub = new ioTHubModule.IoTHub(this.projectRootPath, this.channel);
     await iotHub.updateConfigSettings(scaffoldType);
-    await iotHub.load();
     this.componentList.push(iotHub);
 
+    // Init iotHub Device
     const iotHubDevice = new ioTHubDeviceModule.IoTHubDevice(this.projectRootPath, this.channel, [
       {
         component: iotHub,
@@ -270,9 +267,9 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
       }
     ]);
     await iotHubDevice.updateConfigSettings(scaffoldType);
-    await iotHubDevice.load();
     this.componentList.push(iotHubDevice);
 
+    // Init azure function
     const functionPath = ConfigHandler.get<string>(ConfigKey.functionPath);
     if (functionPath) {
       const functionLocation = path.join(this.projectRootPath, functionPath);
@@ -290,30 +287,22 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
         ]
       );
       await functionApp.updateConfigSettings(scaffoldType);
-      await functionApp.load();
       this.componentList.push(functionApp);
     }
   }
 
   /**
-   * Init Azure components according to configs.
-   * Create and load azure components. Push to component list.
+   * load Azure components from configs.
+   * Update component list with azure components.
    * @param scaffoldType scaffold type
    * @param componentConfigs azure component configs
    */
-  private async initAzureComponentsWithConfig(
-    scaffoldType: ScaffoldType,
-    componentConfigs: AzureComponentConfig[]
-  ): Promise<void> {
-    this.validateProjectRootPath("initialize azure components with configurations", scaffoldType);
-
-    const components: { [key: string]: Component } = {};
+  private async loadAzureComponentsWithConfig(componentConfigs: AzureComponentConfig[]): Promise<void> {
     for (const componentConfig of componentConfigs) {
       switch (componentConfig.type) {
         case ComponentType.IoTHub: {
           const iotHub = new ioTHubModule.IoTHub(this.projectRootPath, this.channel);
           await iotHub.load();
-          components[iotHub.id] = iotHub;
           this.componentList.push(iotHub);
 
           const iothubDevice = new ioTHubDeviceModule.IoTHubDevice(this.projectRootPath, this.channel, [
@@ -323,7 +312,6 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
             }
           ]);
           await iothubDevice.load();
-          components[iothubDevice.id] = iothubDevice;
           this.componentList.push(iothubDevice);
 
           break;
@@ -346,7 +334,6 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
               this.channel
             );
             await functionApp.load();
-            components[functionApp.id] = functionApp;
             this.componentList.push(functionApp);
           }
           break;
@@ -359,12 +346,10 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
   }
 
   /**
-   * Init Azure components and azure configs.
+   * Load project config and init Azure components.
    * @param scaffoldType scaffold type
    */
-  private async initAzureConfig(scaffoldType: ScaffoldType): Promise<void> {
-    this.validateProjectRootPath("initialize azure configurations", scaffoldType);
-
+  private async loadAzureConfigAndInitAzureComponents(scaffoldType: ScaffoldType): Promise<void> {
     const azureConfigFileHandler = new azureComponentConfigModule.AzureConfigFileHandler(this.projectRootPath);
     await azureConfigFileHandler.createIfNotExists(scaffoldType);
 
@@ -372,22 +357,27 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
 
     if (componentConfigs.length === 0) {
       // Support backward compact
-      await this.initAzureComponentsWithoutConfig(scaffoldType);
+      this.initAzureComponentsWithoutConfig(scaffoldType);
     } else {
-      await this.initAzureComponentsWithConfig(scaffoldType, componentConfigs);
+      await this.loadAzureComponentsWithConfig(componentConfigs);
     }
   }
 
-  private async createAzureComponentsWithProjectType(
-    projectType: ProjectTemplateType,
-    scaffoldType: ScaffoldType,
-    workspaceConfig: Workspace
-  ): Promise<void> {
-    this.validateProjectRootPath("init azure components", scaffoldType);
-
-    // initialize the storage for azure component settings
-    const azureConfigFileHandler = new azureComponentConfigModule.AzureConfigFileHandler(this.projectRootPath);
-    await azureConfigFileHandler.createIfNotExists(scaffoldType);
+  /**
+   * Init azure components based on project template type.
+   * Update component list with azure components.
+   * Update azure components information in workspace configuration.
+   * @param projectType project template type
+   * @param workspaceConfig workspace configuration
+   */
+  private initAzureComponents(projectType: ProjectTemplateType, workspaceConfig: Workspace): void {
+    if (!this.projectRootPath) {
+      throw new ArgumentEmptyOrNullError(
+        "init azure components",
+        `project root path: ${this.projectRootPath}`,
+        "Please initialize the project first."
+      );
+    }
 
     switch (projectType) {
       case ProjectTemplateType.Basic:
@@ -402,9 +392,6 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
         const iothub = new ioTHubModule.IoTHub(this.projectRootPath, this.channel);
 
         const functionDir = path.join(this.projectRootPath, IoTWorkspaceProject.folderName.functionDefaultFolderName);
-        if (!(await FileUtility.directoryExists(scaffoldType, functionDir))) {
-          await FileUtility.mkdirRecursively(scaffoldType, functionDir);
-        }
         const azureFunctions = new azureFunctionsModule.AzureFunctions(
           this.projectRootPath,
           functionDir,
@@ -432,9 +419,13 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
     }
   }
 
-  // Init workspace config file path at load time
-  private async loadAndInitWorkspaceConfigFilePath(scaffoldType: ScaffoldType): Promise<void> {
-    this.validateProjectRootPath("init workspace config file path", scaffoldType);
+  /**
+   * Find the workspace config file under project root path and init workspace config file path.
+   * Throw error if workspace config file not exists.
+   * @param scaffoldType scaffold type
+   */
+  private async loadWorkspaceConfigFilePath(scaffoldType: ScaffoldType): Promise<void> {
+    await this.validateProjectRootPathExists("init workspace config file path", scaffoldType);
 
     const workspaceFile = getWorkspaceFile(this.projectRootPath);
     if (!workspaceFile) {

--- a/src/Models/IoTWorkspaceProject.ts
+++ b/src/Models/IoTWorkspaceProject.ts
@@ -97,7 +97,7 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
     }
 
     // Init device component
-    this.initDeviceComponents(boardId);
+    this.initDeviceComponents(boardId, this.deviceRootPath);
     // Load device component
     await Promise.all(
       this.componentList.map(async component => {
@@ -131,7 +131,7 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
     this.iotWorkbenchProjectFilePath = path.join(this.deviceRootPath, FileNames.iotWorkbenchProjectFileName);
 
     // Init device components
-    this.initDeviceComponents(boardId, templateFilesInfo);
+    this.initDeviceComponents(boardId, this.deviceRootPath, templateFilesInfo);
     // init azure components
     this.initAzureComponents(projectType, workspace);
 
@@ -177,7 +177,7 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
   }
 
   async openProject(scaffoldType: ScaffoldType, openInNewWindow: boolean, openScenario: OpenScenario): Promise<void> {
-    this.loadWorkspaceConfigFilePath(scaffoldType);
+    await this.loadWorkspaceConfigFilePath(scaffoldType);
 
     if (!(await FileUtility.fileExists(scaffoldType, this.workspaceConfigFilePath))) {
       throw new FileNotFoundError(
@@ -209,14 +209,15 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
    * Init device components according to board id.
    * Update component list with device.
    * @param boardId board id
+   * @param deviceRootPath device root path
    * @param scaffoldType scaffold type
    * @param templateFilesInfo template files info to scaffold files for device
    */
-  private initDeviceComponents(boardId: string, templateFilesInfo?: TemplateFileInfo[]): void {
-    if (!this.deviceRootPath) {
+  private initDeviceComponents(boardId: string, deviceRootPath: string, templateFilesInfo?: TemplateFileInfo[]): void {
+    if (!deviceRootPath) {
       throw new ArgumentEmptyOrNullError(
         "initialize device",
-        `device root path: ${this.deviceRootPath}`,
+        `device root path: ${deviceRootPath}`,
         "Please initialize the project first."
       );
     }
@@ -227,7 +228,7 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
         this.extensionContext,
         this.channel,
         this.telemetryContext,
-        this.deviceRootPath,
+        deviceRootPath,
         templateFilesInfo
       );
     } else if (boardId === esp32DeviceModule.Esp32Device.boardId) {
@@ -235,7 +236,7 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
         this.extensionContext,
         this.channel,
         this.telemetryContext,
-        this.deviceRootPath,
+        deviceRootPath,
         templateFilesInfo
       );
     } else {
@@ -357,7 +358,7 @@ export class IoTWorkspaceProject extends IoTWorkbenchProjectBase {
 
     if (componentConfigs.length === 0) {
       // Support backward compact
-      this.initAzureComponentsWithoutConfig(scaffoldType);
+      await this.initAzureComponentsWithoutConfig(scaffoldType);
     } else {
       await this.loadAzureComponentsByConfig(componentConfigs);
     }

--- a/src/ProjectEnvironmentConfiger.ts
+++ b/src/ProjectEnvironmentConfiger.ts
@@ -36,7 +36,7 @@ export class ProjectEnvironmentConfiger {
 
     const scaffoldType = ScaffoldType.Local;
 
-    const projectRootPath = utils.getFirstWorkspaceFolderPath();
+    const projectRootPath = utils.getProjectDeviceRootPath();
     if (!projectRootPath) {
       throw new WorkspaceNotOpenError("configure project environment");
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -155,7 +155,7 @@ export function getProjectDeviceRootPath(): string {
     return "";
   }
 
-  // Try get the "Device" folder
+  // Try to get the "Device" folder
   const devicePath = ConfigHandler.get<string>(ConfigKey.devicePath);
   if (devicePath) {
     const deviceFolder = vscode.workspace.workspaceFolders.find(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -144,7 +144,7 @@ export interface FolderQuickPickItem<T = undefined> extends vscode.QuickPickItem
 /**
  * Get project device root path.
  * For iot workspace project, it is the "Device" folder.
- * For iot container project, it is the root path.
+ * For iot containerized project, it is the root path.
  */
 export function getProjectDeviceRootPath(): string {
   if (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,6 +38,7 @@ import { WorkspaceNotOpenError } from "./common/Error/OperationFailedErrors/Work
 import { SystemResourceNotFoundError } from "./common/Error/SystemErrors/SystemResourceNotFoundError";
 import { FileNotFoundError } from "./common/Error/OperationFailedErrors/FileNotFound";
 import { DirectoryNotFoundError } from "./common/Error/OperationFailedErrors/DirectoryNotFoundError";
+import { ConfigHandler } from "./configHandler";
 
 const impor = require("impor")(__dirname);
 const ioTWorkspaceProjectModule = impor(
@@ -141,9 +142,11 @@ export interface FolderQuickPickItem<T = undefined> extends vscode.QuickPickItem
 }
 
 /**
- * Get the first workspace folder path open in current VS Code instance.
+ * Get project device root path.
+ * For iot workspace project, it is the "Device" folder.
+ * For iot container project, it is the root path.
  */
-export function getFirstWorkspaceFolderPath(): string {
+export function getProjectDeviceRootPath(): string {
   if (
     !vscode.workspace.workspaceFolders ||
     vscode.workspace.workspaceFolders.length === 0 ||
@@ -151,6 +154,19 @@ export function getFirstWorkspaceFolderPath(): string {
   ) {
     return "";
   }
+
+  // Try get the "Device" folder
+  const devicePath = ConfigHandler.get<string>(ConfigKey.devicePath);
+  if (devicePath) {
+    const deviceFolder = vscode.workspace.workspaceFolders.find(
+      folder => path.basename(folder.uri.fsPath) === devicePath
+    );
+    if (deviceFolder) {
+      return deviceFolder.uri.fsPath;
+    }
+  }
+
+  // If no "Device" folder found in current workspace, return first workspace folder directly
   return vscode.workspace.workspaceFolders[0].uri.fsPath;
 }
 
@@ -493,7 +509,7 @@ export async function getProjectConfig(
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
 ): Promise<any> {
   let projectConfig: { [key: string]: string } = {};
-  if (await FileUtility.fileExists(type, iotWorkbenchProjectFilePath)) {
+  if (iotWorkbenchProjectFilePath && (await FileUtility.fileExists(type, iotWorkbenchProjectFilePath))) {
     const projectConfigContent = ((await FileUtility.readFile(
       type,
       iotWorkbenchProjectFilePath,
@@ -507,6 +523,9 @@ export async function getProjectConfig(
 }
 
 export function getWorkspaceFile(rootPath: string): string {
+  if (!rootPath) {
+    throw new ArgumentEmptyOrNullError("get workspace file", "root path");
+  }
   const workspaceFiles = fs
     .readdirSync(rootPath)
     .filter(file => path.extname(file).endsWith(FileNames.workspaceExtensionName));
@@ -542,7 +561,6 @@ export async function updateProjectHostTypeConfig(
   if (!projectConfig[`${ConfigKey.workbenchVersion}`]) {
     projectConfig[`${ConfigKey.workbenchVersion}`] = workbenchVersion;
   }
-
   await FileUtility.writeJsonFile(type, iotWorkbenchProjectFilePath, projectConfig);
 }
 
@@ -553,7 +571,7 @@ export async function updateProjectHostTypeConfig(
  * @param scaffoldType
  */
 export async function configExternalCMakeProjectToIoTContainerProject(scaffoldType: ScaffoldType): Promise<void> {
-  const projectRootPath = getFirstWorkspaceFolderPath();
+  const projectRootPath = getProjectDeviceRootPath();
   if (!projectRootPath) {
     throw new WorkspaceNotOpenError("configure external CMake project to IoT container project");
   }
@@ -582,7 +600,7 @@ export async function configExternalCMakeProjectToIoTContainerProject(scaffoldTy
  * Ask to open as workspace.
  */
 export async function properlyOpenIoTWorkspaceProject(telemetryContext: TelemetryContext): Promise<void> {
-  const rootPath = getFirstWorkspaceFolderPath();
+  const rootPath = getProjectDeviceRootPath();
   if (!rootPath) {
     throw new WorkspaceNotOpenError("properly open IoT workspace project");
   }
@@ -598,7 +616,7 @@ export async function properlyOpenIoTWorkspaceProject(telemetryContext: Telemetr
 }
 
 export function isWorkspaceProject(): boolean {
-  const rootPath = getFirstWorkspaceFolderPath();
+  const rootPath = getProjectDeviceRootPath();
   if (!rootPath) {
     return false;
   }
@@ -629,7 +647,7 @@ export async function constructAndLoadIoTProject(
 ): Promise<IoTWorkbenchProjectBase | undefined> {
   const scaffoldType = ScaffoldType.Workspace;
 
-  const projectFileRootPath = getFirstWorkspaceFolderPath();
+  const projectFileRootPath = getProjectDeviceRootPath();
   const projectHostType = await IoTWorkbenchProjectBase.getProjectType(scaffoldType, projectFileRootPath);
 
   let iotProject;


### PR DESCRIPTION
Fix [bug](https://dev.azure.com/mseng/VSIoT/_workitems/edit/1679307):

When creating iot workspace project, steps sequence should be:
init components -> check prerequisites(will check dependent extensions) -> create componens.

This PR move all files creation after prerequisites are checked and satisfied. Thus project will NOT be created if prerequistes are not satisfied.