### PR TITLE
Suppress sending error telemetry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vscode-iot-workbench",
-  "version": "0.14.0-rc",
+  "version": "0.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1317,14 +1317,14 @@
       }
     },
     "applicationinsights": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.4.0.tgz",
-      "integrity": "sha512-TV8MYb0Kw9uE2cdu4V/UvTKdOABkX2+Fga9iDz0zqV7FLrNXfmAugWZmmdTx4JoynYkln3d5CUHY3oVSUEbfFw==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
+      "integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
       "requires": {
         "cls-hooked": "^4.2.2",
         "continuation-local-storage": "^3.2.1",
         "diagnostic-channel": "0.2.0",
-        "diagnostic-channel-publishers": "^0.3.2"
+        "diagnostic-channel-publishers": "^0.3.3"
       }
     },
     "aproba": {
@@ -3030,9 +3030,9 @@
       }
     },
     "diagnostic-channel-publishers": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.3.tgz",
-      "integrity": "sha512-qIocRYU5TrGUkBlDDxaziAK1+squ8Yf2Ls4HldL3xxb/jzmWO2Enux7CvevNKYmF2kDXZ9HiRqwjPsjk8L+i2Q=="
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.4.tgz",
+      "integrity": "sha512-SZ1zMfFiEabf4Qx0Og9V1gMsRoqz3O+5ENkVcNOfI+SMJ3QhQsdEoKX99r0zvreagXot2parPxmrwwUM/ja8ug=="
     },
     "diff": {
       "version": "3.5.0",
@@ -10976,11 +10976,11 @@
       "integrity": "sha512-FuH71MlL6Vj7OC3SpVoB+bZLY7zwuIm8VWwJsuvtxpP3SQXy69BLml5fJNZLIg21/5rkF1EBTu9qy29c4cMD+A=="
     },
     "vscode-extension-telemetry": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.2.tgz",
-      "integrity": "sha512-FSbaZKlIH3VKvBJsKw7v5bESWHXzltji2rtjaJeJglpQH4tfClzwHMzlMXUZGiblV++djEzb1gW8mb5E+wxFsg==",
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry/-/vscode-extension-telemetry-0.1.6.tgz",
+      "integrity": "sha512-rbzSg7k4NnsCdF4Lz0gI4jl3JLXR0hnlmfFgsY8CSDYhXgdoIxcre8jw5rjkobY0xhSDhbG7xCjP8zxskySJ/g==",
       "requires": {
-        "applicationinsights": "1.4.0"
+        "applicationinsights": "1.7.4"
       }
     },
     "vscode-iot-device-cube-sdk": {

--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
     "ssh2": "^0.6.1",
     "validator": "^12.2.0",
     "vscode-express": "^1.0.1",
-    "vscode-extension-telemetry": "^0.1.0",
+    "vscode-extension-telemetry": "^0.1.6",
     "vscode-iot-device-cube-sdk": "^0.1.1",
     "winreg": "^1.2.3"
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -187,7 +187,7 @@ function initDigitalTwinCommand(
         try {
           return await callback(...args);
         } catch (error) {
-          telemetryContext.properties.error = error.name;
+          telemetryContext.properties.errorType = error.name;
           telemetryContext.properties.errorMessage = error.message;
           if (error instanceof UserCancelledError) {
             telemetryContext.properties.result = TelemetryResult.Cancelled;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -51,7 +51,7 @@ export class TelemetryWorker {
       console.log("Unable to initialize telemetry, please make sure AIKey is set in package.json");
       return;
     }
-    this._reporter = new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey);
+    this._reporter = new TelemetryReporter(packageInfo.name, packageInfo.version, packageInfo.aiKey, true);
     this._isInternal = TelemetryWorker.isInternalUser();
   }
 
@@ -97,7 +97,13 @@ export class TelemetryWorker {
     if (!telemetryContext) {
       telemetryContext = this.createContext();
     }
-    this._reporter.sendTelemetryEvent(eventName, telemetryContext.properties, telemetryContext.measurements);
+    if (telemetryContext.properties.result === TelemetryResult.Succeeded) {
+      this._reporter.sendTelemetryEvent(eventName, telemetryContext.properties, telemetryContext.measurements);
+    } else {
+      this._reporter.sendTelemetryErrorEvent(eventName, telemetryContext.properties, telemetryContext.measurements, [
+        "errorMessage"
+      ]);
+    }
   }
 
   /**


### PR DESCRIPTION
1. update dependency "vscode-extension-telemetry" to version 0.1.6
2. set firstParty = true for TelemetryReporter.
3. use sendTelemetryErrorEvent to suppress sending error telemetry.
4. update property name of error.name from error to errorType for initDigitalTwinCommand.