### PR TITLE
Update the Readme to align with Workbench 0.16.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ The **Azure IoT Device Workbench** is a Visual Studio Code extension that provid
 
 ### Develop device using IoT Plug and Play
 
-[IoT Plug and Play <sup>public preview</sup>](https://docs.microsoft.com/azure/iot-pnp/) is a *device capability model schema* that describes device capabilities. The Azure IoT Device Workbench extension provides an integrated environment to author IoT Plug and Play *device capability models (DCM)* and *interfaces*, publish to model repositories, and generate skeleton C code to implement the device application.
+[IoT Plug and Play <sup>public preview</sup>](https://docs.microsoft.com/azure/iot-pnp/) is a *device capability model schema* that describes device capabilities. If you are using the Azure IoT Device Workbench extension **0.16.0 release or above**, you could create the model file with [DTDL extension](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.vscode-dtdl). If you are using the release before **0.16.0**, this extension provides an integrated environment to author IoT Plug and Play *device capability models (DCM)* and *interfaces*, publish to model repositories, and generate skeleton C code to implement the device application.
 
 Learn how to get started with IoT Plug and Play and use the Device Workbench extension to build an IoT Plug and Play device:
 
 - [What is IoT Plug and Play](https://docs.microsoft.com/azure/iot-pnp/overview-iot-plug-and-play) and the [Digital Twin Definition Language (DTDL)](https://aka.ms/DTDL) that enables it.
-- [Quickstart: Use a device capability model to create an IoT Plug and Play device](https://docs.microsoft.com/azure/iot-pnp/quickstart-create-pnp-device)
-- [Build an IoT Plug and Play Preview device that's ready for certification](https://docs.microsoft.com/azure/iot-pnp/tutorial-build-device-certification)
-- [Use Azure IoT Device Workbench extension in Visual Studio Code](https://docs.microsoft.com/azure/iot-pnp/howto-develop-with-vs-vscode)
-- [Connect an MXChip IoT DevKit device to your Azure IoT Central application via IoT Plug and Play](https://docs.microsoft.com/azure/iot-central/howto-connect-devkit-pnp)
+- [Quickstart: Use a device capability model to create an IoT Plug and Play device](https://docs.microsoft.com/azure/iot-pnp/quickstart-create-pnp-device) <sup>[[1](#notes)]</sup>
+- [Build an IoT Plug and Play Preview device that's ready for certification](https://docs.microsoft.com/azure/iot-pnp/tutorial-build-device-certification) <sup>[[1](#notes)]</sup>
+- [Use Azure IoT Device Workbench extension in Visual Studio Code](https://docs.microsoft.com/azure/iot-pnp/howto-develop-with-vs-vscode) <sup>[[1](#notes)]</sup>
+- [Connect an MXChip IoT DevKit device to your Azure IoT Central application via IoT Plug and Play](https://docs.microsoft.com/azure/iot-central/howto-connect-devkit-pnp) <sup>[[1](#notes)]</sup>
 
 ### Develop on generic device
 
@@ -86,7 +86,7 @@ Please take the [survey](https://www.surveymonkey.com/r/C7NY7KJ) to let us know 
 
 ## Commands
 
-### IoT Plug and Play
+### IoT Plug and Play  <sup>[[1](#notes)]</sup>
 
 | Command | Description |
 | --- | --- |
@@ -110,6 +110,10 @@ Please take the [survey](https://www.surveymonkey.com/r/C7NY7KJ) to let us know 
 | `Azure IoT Device Workbench: Configure Device Settings...`  | Manage the settings on the device. |
 | `Azure IoT Device Workbench: Set Workbench Path` | Set the default path for Azure IoT Device Workbench. |
 | `Azure IoT Device Workbench: Help` | Get help for Azure IoT Device Workbench. |
+
+# <a name="notes"></a>
+## Notes
+1. Deprecated for Azure IoT Device Workbench 0.16.0 or above
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -11,24 +11,11 @@
 
 ## Overview
 
-The **Azure IoT Device Workbench** is a Visual Studio Code extension that provides an integrated environment to code, build, deploy, and debug your IoT device project with multiple Azure services supported. 
+The **Azure IoT Device Workbench** is a Visual Studio Code extension that provides an integrated environment to code, build, deploy, and debug your IoT device project with multiple Azure services supported.
+
+If you would like to develop device using [**IoT Plug and Play <sup>preview refresh</sup>**](https://docs.microsoft.com/azure/iot-pnp/) and the [Digital Twin Definition Language (DTDL)](https://aka.ms/DTDL), you could refer to the [DTDL extension](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.vscode-dtdl) to get intellisense completion and syntax validation of DTDL.
 
 ## Get Started
-
-### Develop device using IoT Plug and Play
-
-[**IoT Plug and Play <sup>preview refresh</sup>**](https://docs.microsoft.com/azure/iot-pnp/) is a *device capability model schema* that describes device capabilities. Learn how to get started with IoT Plug and Play:
-
-- [What is IoT Plug and Play](https://docs.microsoft.com/azure/iot-pnp/overview-iot-plug-and-play) and the [Digital Twin Definition Language (DTDL)](https://aka.ms/DTDL) that enables it.
-- Programming with The [DTDL extension](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.vscode-dtdl) to get intellisense completion and syntax validation of DTDL.
-
-
-If you are using Azure IoT Device Workbench extention before **0.16.0**, this extension provides an integrated environment to author IoT **Plug and Play <sup>public preview</sup>** *device capability models (DCM)* and *interfaces*, publish to model repositories, and generate skeleton C code to implement the device application. Learn how to get started with IoT Plug and Play <sup>public preview</sup> and use the Device Workbench extension to build an IoT Plug and Play device:
-- [What is IoT Plug and Play](https://docs.microsoft.com/azure/iot-pnp/overview-iot-plug-and-play) and the [Digital Twin Definition Language (DTDL)](https://aka.ms/DTDL) that enables it.
-- [Quickstart: Use a device capability model to create an IoT Plug and Play device](https://docs.microsoft.com/azure/iot-pnp/quickstart-create-pnp-device) 
-- [Build an IoT Plug and Play Preview device that's ready for certification](https://docs.microsoft.com/azure/iot-pnp/tutorial-build-device-certification) 
-- [Use Azure IoT Device Workbench extension in Visual Studio Code](https://docs.microsoft.com/azure/iot-pnp/howto-develop-with-vs-vscode) 
-- [Connect an MXChip IoT DevKit device to your Azure IoT Central application via IoT Plug and Play](https://docs.microsoft.com/azure/iot-central/howto-connect-devkit-pnp) 
 
 ### Develop on generic device
 
@@ -87,6 +74,19 @@ Here are a set of tutorials to help you get started:
 
 Please take the [survey](https://www.surveymonkey.com/r/C7NY7KJ) to let us know extra device platforms and languages you want to see support in Device Workbench.
 
+
+### Develop device using IoT Plug and Play
+***This section is deprecated for Azure IoT Device Workbench 0.16.0 or above.***
+
+If you are using Azure IoT Device Workbench extention before **0.16.0**, this extension provides an integrated environment to author IoT **Plug and Play <sup>public preview</sup>** *device capability models (DCM)* and *interfaces*, publish to model repositories, and generate skeleton C code to implement the device application.
+
+Learn how to get started with IoT Plug and Play <sup>public preview</sup> and use the Device Workbench extension to build an IoT Plug and Play device:
+- [What is IoT Plug and Play](https://docs.microsoft.com/azure/iot-pnp/overview-iot-plug-and-play) and the [Digital Twin Definition Language (DTDL)](https://aka.ms/DTDL) that enables it.
+- [Quickstart: Use a device capability model to create an IoT Plug and Play device](https://docs.microsoft.com/azure/iot-pnp/quickstart-create-pnp-device)
+- [Build an IoT Plug and Play Preview device that's ready for certification](https://docs.microsoft.com/azure/iot-pnp/tutorial-build-device-certification)
+- [Use Azure IoT Device Workbench extension in Visual Studio Code](https://docs.microsoft.com/azure/iot-pnp/howto-develop-with-vs-vscode)
+- [Connect an MXChip IoT DevKit device to your Azure IoT Central application via IoT Plug and Play](https://docs.microsoft.com/azure/iot-central/howto-connect-devkit-pnp)
+
 ## Commands
 
 ### Generic device development
@@ -104,7 +104,7 @@ Please take the [survey](https://www.surveymonkey.com/r/C7NY7KJ) to let us know 
 | `Azure IoT Device Workbench: Help` | Get help for Azure IoT Device Workbench. |
 
 ### IoT Plug and Play 
-***These commands are deprecated for Azure IoT Device Workbench 0.16.0 or above***
+***These commands are deprecated for Azure IoT Device Workbench 0.16.0 or above.***
 
 | Command | Description |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -11,21 +11,24 @@
 
 ## Overview
 
-The **Azure IoT Device Workbench** is a Visual Studio Code extension that provides an integrated environment to code, build, deploy, and debug your IoT device project with multiple Azure services supported. The extension also supports working with [IoT Plug and Play](https://docs.microsoft.com/azure/iot-pnp/overview-iot-plug-and-play) by defining *device capability model* schemas and generating skeleton device code and projects.
+The **Azure IoT Device Workbench** is a Visual Studio Code extension that provides an integrated environment to code, build, deploy, and debug your IoT device project with multiple Azure services supported. 
 
 ## Get Started
 
 ### Develop device using IoT Plug and Play
 
-[IoT Plug and Play <sup>public preview</sup>](https://docs.microsoft.com/azure/iot-pnp/) is a *device capability model schema* that describes device capabilities. If you are using the Azure IoT Device Workbench extension **0.16.0 release or above**, you could create the model file with [DTDL extension](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.vscode-dtdl). If you are using the release before **0.16.0**, this extension provides an integrated environment to author IoT Plug and Play *device capability models (DCM)* and *interfaces*, publish to model repositories, and generate skeleton C code to implement the device application.
-
-Learn how to get started with IoT Plug and Play and use the Device Workbench extension to build an IoT Plug and Play device:
+[**IoT Plug and Play <sup>preview refresh</sup>**](https://docs.microsoft.com/azure/iot-pnp/) is a *device capability model schema* that describes device capabilities. Learn how to get started with IoT Plug and Play:
 
 - [What is IoT Plug and Play](https://docs.microsoft.com/azure/iot-pnp/overview-iot-plug-and-play) and the [Digital Twin Definition Language (DTDL)](https://aka.ms/DTDL) that enables it.
-- [Quickstart: Use a device capability model to create an IoT Plug and Play device](https://docs.microsoft.com/azure/iot-pnp/quickstart-create-pnp-device) <sup>[[1](#notes)]</sup>
-- [Build an IoT Plug and Play Preview device that's ready for certification](https://docs.microsoft.com/azure/iot-pnp/tutorial-build-device-certification) <sup>[[1](#notes)]</sup>
-- [Use Azure IoT Device Workbench extension in Visual Studio Code](https://docs.microsoft.com/azure/iot-pnp/howto-develop-with-vs-vscode) <sup>[[1](#notes)]</sup>
-- [Connect an MXChip IoT DevKit device to your Azure IoT Central application via IoT Plug and Play](https://docs.microsoft.com/azure/iot-central/howto-connect-devkit-pnp) <sup>[[1](#notes)]</sup>
+- Programming with The [DTDL extension](https://marketplace.visualstudio.com/items?itemName=vsciot-vscode.vscode-dtdl) to get intellisense completion and syntax validation of DTDL.
+
+
+If you are using Azure IoT Device Workbench extention before **0.16.0**, this extension provides an integrated environment to author IoT **Plug and Play <sup>public preview</sup>** *device capability models (DCM)* and *interfaces*, publish to model repositories, and generate skeleton C code to implement the device application. Learn how to get started with IoT Plug and Play <sup>public preview</sup> and use the Device Workbench extension to build an IoT Plug and Play device:
+- [What is IoT Plug and Play](https://docs.microsoft.com/azure/iot-pnp/overview-iot-plug-and-play) and the [Digital Twin Definition Language (DTDL)](https://aka.ms/DTDL) that enables it.
+- [Quickstart: Use a device capability model to create an IoT Plug and Play device](https://docs.microsoft.com/azure/iot-pnp/quickstart-create-pnp-device) 
+- [Build an IoT Plug and Play Preview device that's ready for certification](https://docs.microsoft.com/azure/iot-pnp/tutorial-build-device-certification) 
+- [Use Azure IoT Device Workbench extension in Visual Studio Code](https://docs.microsoft.com/azure/iot-pnp/howto-develop-with-vs-vscode) 
+- [Connect an MXChip IoT DevKit device to your Azure IoT Central application via IoT Plug and Play](https://docs.microsoft.com/azure/iot-central/howto-connect-devkit-pnp) 
 
 ### Develop on generic device
 
@@ -86,17 +89,6 @@ Please take the [survey](https://www.surveymonkey.com/r/C7NY7KJ) to let us know 
 
 ## Commands
 
-### IoT Plug and Play  <sup>[[1](#notes)]</sup>
-
-| Command | Description |
-| --- | --- |
-| `IoT Plug and Play: Create Capability Model...`  | Create new IoT Plug and Play device capability model file. |
-| `IoT Plug and Play: Create Interface...` | Create new IoT Plug and Play interface file. |
-| `IoT Plug and Play: Generate Device Code Stub...` | Generate skeleton device code and project based on given device capability model file. |
-| `IoT Plug and Play: Open Model Repository...`  | Open Public or Company Model Repository view to manage device model files. |
-| `IoT Plug and Play: Submit files to Model Repository...`  | Submit files to model repository. |
-| `IoT Plug and Play: Sign out Model Repository`  | Sign out the Company Model Repository. |
-
 ### Generic device development
 
 | Command | Description |
@@ -111,9 +103,17 @@ Please take the [survey](https://www.surveymonkey.com/r/C7NY7KJ) to let us know 
 | `Azure IoT Device Workbench: Set Workbench Path` | Set the default path for Azure IoT Device Workbench. |
 | `Azure IoT Device Workbench: Help` | Get help for Azure IoT Device Workbench. |
 
-# <a name="notes"></a>
-## Notes
-1. Deprecated for Azure IoT Device Workbench 0.16.0 or above
+### IoT Plug and Play 
+***These commands are deprecated for Azure IoT Device Workbench 0.16.0 or above***
+
+| Command | Description |
+| --- | --- |
+| `IoT Plug and Play: Create Capability Model...`  | Create new IoT Plug and Play device capability model file. |
+| `IoT Plug and Play: Create Interface...` | Create new IoT Plug and Play interface file. |
+| `IoT Plug and Play: Generate Device Code Stub...` | Generate skeleton device code and project based on given device capability model file. |
+| `IoT Plug and Play: Open Model Repository...`  | Open Public or Company Model Repository view to manage device model files. |
+| `IoT Plug and Play: Submit files to Model Repository...`  | Submit files to model repository. |
+| `IoT Plug and Play: Sign out Model Repository`  | Sign out the Company Model Repository. |
 
 ## Documentation
 


### PR DESCRIPTION
Changes

- Update the wording from Public Preview to Preview Refresh 

- Update the Overview, Get Started and Commands section to align with Workbench 0.16.0. Adding comments for old or deprecated contents. 